### PR TITLE
Making the Hub Nostr First

### DIFF
--- a/host/index.js
+++ b/host/index.js
@@ -114,7 +114,7 @@ app.use(async (req, res, next) => {
         return next();
       }
 
-      const indexerUrl = "https://tbtc.indexer.angor.io/api/query/Angor/projects/";
+      const indexerUrl = "https://signet.angor.online/api/query/Angor/projects/";
 
       // Fetch project metadata if projectId exists
       const response = await fetch(indexerUrl + projectId);

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, signal, inject, effect } from '@angular/core';
-import { ProfileUpdate, ProjectUpdate, RelayService } from './relay.service';
+import { Injectable, signal, inject } from '@angular/core';
+import { ProjectUpdate, RelayService } from './relay.service';
 import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
 import { NetworkService } from './network.service';
 import { DenyService } from './deny.service';
 import { ExternalIdentity } from '../models/models';
+import { NostrProjectVerificationService } from './nostr-project-verification.service';
 
 export interface IndexerConfig {
   mainnet: IndexerEntry[];
@@ -97,12 +98,16 @@ export interface NetworkStats {
 export class IndexerService {
   private readonly LIMIT = 8;
   private indexerUrl = 'https://tbtc.indexer.angor.io/';
-  private offset = -1000;
-  private totalItems = 0;
-  private totalProjectsFetched = false;
+
+  // Nostr-first pagination: track the oldest event timestamp seen so far.
+  // On the next fetch we use `until = nostrUntil` so we get events older than
+  // the current page without re-fetching the same ones.
+  private nostrUntil: number | undefined = undefined;
+  private nostrFetchComplete = false;
+
   private relay = inject(RelayService);
-  private readonly pageSize = 100;
   private denyService = inject(DenyService);
+  private verification = inject(NostrProjectVerificationService);
 
   public loading = signal<boolean>(false);
   public projects = signal<IndexedProject[]>([]);
@@ -128,8 +133,9 @@ export class IndexerService {
       this.updateProjectMetadata(update);
     });
 
-    this.relay.projectUpdates.subscribe((update) => {
-      this.updateProjectDetails(update);
+    // Update project details when a verified Nostr event is emitted.
+    this.relay.projectUpdates.subscribe((event) => {
+      this.updateProjectDetails(event);
     });
 
 
@@ -298,7 +304,7 @@ export class IndexerService {
     const config = this.getIndexerConfig();
     const indexers = isMainnet ? config.mainnet : config.testnet;
     const primary = indexers.find(i => i.isPrimary) || indexers[0];
-    
+
     if (!primary) {
       this.error.set(errorMsg);
       return;
@@ -315,7 +321,7 @@ export class IndexerService {
       } catch (retryError) {
         console.debug(`Retry ${i + 1} failed:`, retryError);
       }
-      
+
       // Wait before next retry (except for the last attempt)
       if (i < retryCount - 1) {
         await new Promise(resolve => setTimeout(resolve, delayMs));
@@ -364,36 +370,53 @@ export class IndexerService {
     );
   }
 
-  private updateProjectDetails(details: any) {
-    this.projects.update((projects) =>
-      projects.map((project) => {
-        if (project.projectIdentifier === details.projectIdentifier) {
-
-          if (
-            !project.details_created_at ||
-            details.created_at > project.details_created_at
-          ) {
-            return {
-              ...project,
-              details,
-              details_created_at: details.created_at,
-            };
+  /**
+   * Updates a project's details when a verified kind 3030 event arrives via
+   */
+  private updateProjectDetails(event: NDKEvent) {
+    try {
+      const details: ProjectUpdate = JSON.parse(event.content);
+      this.projects.update((projects) =>
+        projects.map((project) => {
+          if (project.projectIdentifier === details.projectIdentifier) {
+            if (
+              !project.details_created_at ||
+              event.created_at! > project.details_created_at
+            ) {
+              return {
+                ...project,
+                details,
+                details_created_at: event.created_at,
+              };
+            }
           }
-        }
-        return project;
-      })
-    );
+          return project;
+        })
+      );
+    } catch {
+    }
   }
 
+  /**
+   * Nostr-first project fetch with OP_RETURN verification.
+   *
+   * Flow:
+   *   Subscribe to kind 3030 events on Nostr relays (time-paginated via `until`)
+   *   For each event, parse projectIdentifier from content
+   *   Check deny list
+   *  Fetch the project from the indexer to obtain trxId
+   *   Fetch the raw transaction hex and decode the OP_RETURN
+   *   Verify the OP_RETURN value matches the Nostr event ID
+   *   Add only verified projects to the signal
+   */
   async fetchProjects(reset = false): Promise<void> {
     if (reset) {
-      this.offset = -1000;
-      this.totalProjectsFetched = false;
-      this.totalItems = 0;
+      this.nostrUntil = undefined;
+      this.nostrFetchComplete = false;
       this.projects.set([]);
     }
 
-    if (this.loading()) {
+    if (this.loading() || this.nostrFetchComplete) {
       return;
     }
 
@@ -402,84 +425,124 @@ export class IndexerService {
 
       this.loading.set(true);
       this.error.set(null);
-      let limit = this.LIMIT;
 
-      const isFirstLoad = this.offset === -1000;
+      //Fetch kind 3030 events from Nostr relays
+      const nostrEvents = await this.relay.fetchNostrProjects(this.LIMIT, this.nostrUntil);
 
-      if (!isFirstLoad && this.offset < 0) {
-        limit = this.LIMIT + this.offset;
-        console.log('LIMIT SUBSTRACTED:', limit);
-        this.offset = 0;
-        this.totalProjectsFetched = true;
-      }
-
-      if (limit <= 0) {
-        this.loading.set(false);
-        this.totalProjectsFetched = true;
+      if (nostrEvents.length === 0) {
+        this.nostrFetchComplete = true;
         return;
       }
 
-      const params = new URLSearchParams();
-      params.append('limit', limit.toString());
-
-      if (!isFirstLoad && this.offset >= 0) {
-        params.append('offset', this.offset.toString());
+      // Mark complete if we received fewer events than requested (end of feed)
+      if (nostrEvents.length < this.LIMIT) {
+        this.nostrFetchComplete = true;
       }
 
-      const url = `${this.indexerUrl}api/query/Angor/projects?${params.toString()}`;
+      // Advance the time-based pagination cursor to just before the oldest event
+      const minTimestamp = nostrEvents.reduce(
+        (min, e) => Math.min(min, e.created_at ?? Infinity),
+        Infinity
+      );
+      if (minTimestamp !== Infinity) {
+        this.nostrUntil = minTimestamp - 1;
+      }
 
+      // Verify each event in parallel
+      const verifiedProjects = await Promise.all(
+        nostrEvents.map(async (event): Promise<IndexedProject | null> => {
+          try {
+            if (!event.id) return null;
 
-      const { data: response, headers } = await this.fetchJson<IndexedProject[]>(url);
+            //  Parse project details from Nostr event content
+            let projectDetails: ProjectUpdate;
+            try {
+              projectDetails = JSON.parse(event.content) as ProjectUpdate;
+            } catch {
+              return null;
+            }
 
-      if (Array.isArray(response) && response.length > 0) {
-        const filteredResponse: IndexedProject[] = [];
-        for (const item of response) {
-          const isDenied = await this.denyService.isEventDenied(item.projectIdentifier);
-          if (!isDenied) {
-            filteredResponse.push(item);
+            const projectIdentifier = projectDetails.projectIdentifier;
+            if (!projectIdentifier) return null;
+
+            //  Check deny list
+            if (await this.denyService.isEventDenied(projectIdentifier)) return null;
+
+            const alreadyLoaded = this.projects().some(
+              (p) => p.projectIdentifier === projectIdentifier
+            );
+            if (alreadyLoaded) return null;
+
+            //  Fetch project from indexer to get trxId and on-chain metadata
+            let indexerData: IndexedProject;
+            try {
+              const result = await this.fetchJson<IndexedProject>(
+                `${this.indexerUrl}api/query/Angor/projects/${projectIdentifier}`
+              );
+              indexerData = result.data;
+            } catch {
+              // Project not indexed yet or indexer error — skip silently
+              return null;
+            }
+
+            if (!indexerData?.trxId) return null;
+
+            //  Fetch raw transaction hex
+            let txHex: string | null = null;
+            try {
+              const result = await this.fetchJson<string>(
+                `${this.indexerUrl}api/query/transaction/${indexerData.trxId}/hex`
+              );
+              txHex = result.data ?? null;
+            } catch {
+              return null;
+            }
+
+            if (!txHex) return null;
+
+            //  Verify OP_RETURN embeds the Nostr event ID
+            const isVerified = this.verification.verifyEventInTransaction(txHex, event.id);
+            if (!isVerified) {
+              console.warn(
+                `[Angor] OP_RETURN mismatch for project ${projectIdentifier}. ` +
+                `Nostr event ID: ${event.id}, ` +
+                `OP_RETURN: ${this.verification.extractOpReturnEventId(txHex)}`
+              );
+              return null;
+            }
+
+            //  Build verified IndexedProject combining Nostr + indexer data
+            const project: IndexedProject = {
+              ...indexerData,
+              nostrEventId: event.id,  
+              details: projectDetails,
+              details_created_at: event.created_at,
+            };
+
+            // Kick off async profile fetch (result arrives via profileUpdates subject)
+            if (projectDetails.nostrPubKey) {
+              this.relay.fetchProfile([projectDetails.nostrPubKey]);
+            }
+
+            // Emit verified event so component subscriptions receive the update
+            this.relay.projectUpdates.next(event);
+
+            return project;
+          } catch (err) {
+            console.error('[Angor] Error processing Nostr event:', err);
+            return null;
           }
-        }
+        })
+      );
 
-        if (filteredResponse.length === 0 && response.length > 0) {
-          console.log(`All ${response.length} fetched projects were denied.`);
-        }
-
-        if (isFirstLoad) {
-          this.totalItems = parseInt(headers.get('pagination-total') || '0');
-          
-          this.offset = Math.max(0, this.totalItems - limit);
-        } else {
-          this.offset = Math.max(0, this.offset - this.LIMIT);
-        }
-
-        if (this.offset === 0 && !isFirstLoad) {
-          this.totalProjectsFetched = true;
-          console.log('Reached beginning of projects list');
-        }
-
-        if (filteredResponse.length > 0) {
-          this.projects.update((existing) => {
-            const merged = [...existing];
-            const existingIds = new Set(existing.map(p => p.projectIdentifier));
-
-            filteredResponse.forEach((newProject) => {
-              if (!existingIds.has(newProject.projectIdentifier)) {
-                merged.push(newProject);
-                existingIds.add(newProject.projectIdentifier);
-              }
-            });
-
-            return merged;
-          });
-
-          const eventIds = filteredResponse.map((project) => project.nostrEventId);
-
-          if (eventIds.length > 0) {
-            this.relay.fetchListData(eventIds);
-          }
-        }
-      } else {
-        this.totalProjectsFetched = true;
+      // Add verified projects to the signal (deduplicate by projectIdentifier)
+      const newProjects = verifiedProjects.filter((p): p is IndexedProject => p !== null);
+      if (newProjects.length > 0) {
+        this.projects.update((existing) => {
+          const existingIds = new Set(existing.map((p) => p.projectIdentifier));
+          const unique = newProjects.filter((p) => !existingIds.has(p.projectIdentifier));
+          return [...existing, ...unique];
+        });
       }
     } catch (err) {
       await this.setErrorWithRetry(
@@ -491,28 +554,17 @@ export class IndexerService {
     }
   }
 
-  private async fetchProjectsBatch(offset: number, limit: number) {
-    console.log('fetchProjectsBatch');
-
-
-
-    if (offset < limit) {
-      console.log('LIMIT HIGHER THAN OFFSET!!', offset, limit);
-      limit = offset;
-    }
-
-    const url = `${this.indexerUrl}api/query/Angor/projects?offset=${offset}&limit=${limit}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return await response.json();
-  }
-
   getProject(id: string): IndexedProject | undefined {
     return this.projects().find((p) => p.projectIdentifier === id);
   }
 
+  /**
+   * Fetches a single project by its identifier.
+   *
+   * Uses OP_RETURN verification to ensure the Nostr event ID stored in the
+   * indexer is authentic: we decode the founding transaction's OP_RETURN and
+   * replace the indexer-supplied nostrEventId with the on-chain value.
+   */
   async fetchProject(id: string): Promise<IndexedProject | null> {
 
     await this.denyService.loadDenyList();
@@ -523,18 +575,51 @@ export class IndexerService {
 
     try {
       this.loading.set(true);
-      const project = await this.fetchJson<IndexedProject>(
+      const result = await this.fetchJson<IndexedProject>(
         `${this.indexerUrl}api/query/Angor/projects/${id}`
       );
-      if (project && project.data) {
+      const project = result.data;
 
-        if (await this.denyService.isEventDenied(project.data.projectIdentifier)) {
-          this.error.set(`Project ${id} is not available.`);
-          return null;
+      if (!project) return null;
+
+      if (await this.denyService.isEventDenied(project.projectIdentifier)) {
+        this.error.set(`Project ${id} is not available.`);
+        return null;
+      }
+
+      // Verify the Nostr event ID via OP_RETURN on the founding transaction
+      if (project.trxId) {
+        try {
+          const txResult = await this.fetchJson<string>(
+            `${this.indexerUrl}api/query/transaction/${project.trxId}/hex`
+          );
+          const txHex = txResult.data;
+
+          if (txHex) {
+            const embeddedEventId = this.verification.extractOpReturnEventId(txHex);
+            if (embeddedEventId) {
+              if (embeddedEventId !== project.nostrEventId.toLowerCase()) {
+                console.warn(
+                  `[Angor] nostrEventId mismatch for project ${id}. ` +
+                  `Indexer: ${project.nostrEventId}, OP_RETURN: ${embeddedEventId}. ` +
+                  `Using OP_RETURN value as authoritative.`
+                );
+              }
+              // Replace with the on-chain-verified event ID
+              project.nostrEventId = embeddedEventId;
+            } else {
+              console.warn(
+                `[Angor] No OP_RETURN found in transaction ${project.trxId} for project ${id}`
+              );
+            }
+          }
+        } catch (err) {
+          // fall back to the indexer-supplied nostrEventId
+          console.warn(`[Angor] Could not verify OP_RETURN for project ${id}:`, err);
         }
       }
 
-      return project.data;
+      return project;
     } catch (err) {
       await this.setErrorWithRetry(
         err instanceof Error ? err.message : `Failed to fetch project ${id}`
@@ -746,32 +831,39 @@ export class IndexerService {
   }
 
   async loadMore(): Promise<void> {
-    if (!this.totalProjectsFetched) {
+    if (!this.nostrFetchComplete) {
       await this.fetchProjects();
     }
   }
 
   resetProjects(): void {
-    this.offset = -1000;
-    this.totalProjectsFetched = false;
-    this.totalItems = 0;
+    this.nostrUntil = undefined;
+    this.nostrFetchComplete = false;
     this.projects.set([]);
     this.fetchProjects(true);
   }
 
   isComplete(): boolean {
-    return this.totalProjectsFetched;
+    return this.nostrFetchComplete;
   }
 
-  restoreOffset(offset: number) {
-    this.offset = offset;
+  /**
+   * Restores the Nostr pagination cursor (nostrUntil timestamp) when navigating
+   * back to the explore page
+   */
+  restoreOffset(until: number) {
+    this.nostrUntil = until > 0 ? until : undefined;
   }
 
+  /**
+   * Returns the current Nostr pagination cursor as a number so ExploreStateService
+   */
   getCurrentOffset(): number {
-    return this.offset;
+    return this.nostrUntil ?? 0;
   }
 
   getTotalItems(): number {
-    return this.totalItems;
+    // Total items is not available with Nostr-first pagination
+    return this.projects().length;
   }
 }

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -77,19 +77,16 @@ export interface AddressBalance {
 export interface Transaction {
   id: string;
   hex?: string;
-
 }
 
 export interface Block {
   hash: string;
   height: number;
-
 }
 
 export interface NetworkStats {
   connections: number;
   blockHeight: number;
-
 }
 
 @Injectable({
@@ -99,11 +96,10 @@ export class IndexerService {
   private readonly LIMIT = 8;
   private indexerUrl = 'https://tbtc.indexer.angor.io/';
 
-  // Nostr-first pagination: track the oldest event timestamp seen so far.
-  // On the next fetch we use `until = nostrUntil` so we get events older than
-  // the current page without re-fetching the same ones.
-  private nostrUntil: number | undefined = undefined;
-  private nostrFetchComplete = false;
+  // Offset-based pagination (same as original — restores reliable project listing)
+  private offset = -1000;
+  private totalItems = 0;
+  private totalProjectsFetched = false;
 
   private relay = inject(RelayService);
   private denyService = inject(DenyService);
@@ -113,7 +109,6 @@ export class IndexerService {
   public projects = signal<IndexedProject[]>([]);
   public error = signal<string | null>(null);
   private network = inject(NetworkService);
-
 
   public indexers = signal<IndexerConfig>({
     mainnet: [
@@ -138,13 +133,8 @@ export class IndexerService {
       this.updateProjectDetails(event);
     });
 
-
     this.loadIndexerConfig();
-
-
     this.updateActiveIndexer();
-
-
     this.denyService.loadDenyList();
   }
 
@@ -156,7 +146,6 @@ export class IndexerService {
         this.indexers.set(config);
       } catch (error) {
         console.error('Failed to parse saved indexer config', error);
-
       }
     }
   }
@@ -202,8 +191,6 @@ export class IndexerService {
   updateActiveIndexer(): void {
     const isMain = this.network.isMain();
     this.indexerUrl = this.getPrimaryIndexerUrl(isMain);
-
-
     this.resetProjects();
   }
 
@@ -222,12 +209,10 @@ export class IndexerService {
   }
 
   addIndexer(url: string, isMainnet: boolean): boolean {
-
     let normalizedUrl = url;
     if (!normalizedUrl.endsWith('/')) {
       normalizedUrl += '/';
     }
-
 
     const networkKey = isMainnet ? 'mainnet' : 'testnet';
     const exists = this.indexers()[networkKey].some(indexer => indexer.url === normalizedUrl);
@@ -235,7 +220,6 @@ export class IndexerService {
     if (exists) {
       return false;
     }
-
 
     this.indexers.update(config => {
       const networkIndexers = config[networkKey];
@@ -255,9 +239,7 @@ export class IndexerService {
     const networkKey = isMainnet ? 'mainnet' : 'testnet';
 
     this.indexers.update(config => {
-
       const filteredIndexers = config[networkKey].filter(indexer => indexer.url !== url);
-
 
       if (filteredIndexers.length > 0 && !filteredIndexers.some(i => i.isPrimary)) {
         filteredIndexers[0].isPrimary = true;
@@ -298,7 +280,6 @@ export class IndexerService {
     return false;
   }
 
-
   async setErrorWithRetry(errorMsg: string, retryCount = 1, delayMs = 1000): Promise<void> {
     const isMainnet = this.network.isMain();
     const config = this.getIndexerConfig();
@@ -314,7 +295,6 @@ export class IndexerService {
       try {
         const isOnline = await this.testIndexerConnection(primary.url);
         if (isOnline) {
-          // Connection restored, do not show error
           console.log(`Indexer connection restored after ${i + 1} attempt(s)`);
           return;
         }
@@ -322,13 +302,11 @@ export class IndexerService {
         console.debug(`Retry ${i + 1} failed:`, retryError);
       }
 
-      // Wait before next retry (except for the last attempt)
       if (i < retryCount - 1) {
         await new Promise(resolve => setTimeout(resolve, delayMs));
       }
     }
 
-    // All retries failed, show error
     console.warn(`Indexer connection failed after ${retryCount} attempts, showing error modal`);
     this.error.set(errorMsg);
   }
@@ -346,6 +324,27 @@ export class IndexerService {
     };
   }
 
+  /**
+   * Fetches a raw transaction hex string.
+   * The /hex endpoint may return a plain text hex string (not JSON)
+   */
+  private async fetchTxHex(txId: string): Promise<string | null> {
+    try {
+      const url = `${this.indexerUrl}api/query/transaction/${txId}/hex`;
+      const response = await fetch(url);
+      if (!response.ok) return null;
+      const text = (await response.text()).trim();
+      if (!text) return null;
+      // Handle both plain hex and a JSON-encoded string 
+      if (text.startsWith('"')) {
+        return JSON.parse(text) as string;
+      }
+      return text;
+    } catch {
+      return null;
+    }
+  }
+
   private updateProjectMetadata(event: NDKEvent) {
     const pubkey = event.pubkey;
     const metadata = JSON.parse(event.content) as NDKUserProfile;
@@ -353,7 +352,6 @@ export class IndexerService {
     this.projects.update((projects) =>
       projects.map((project) => {
         if (project.founderKey === pubkey) {
-
           if (
             !project.metadata_created_at ||
             event.created_at! > project.metadata_created_at
@@ -398,25 +396,34 @@ export class IndexerService {
   }
 
   /**
-   * Nostr-first project fetch with OP_RETURN verification.
+   * Fetches a paginated batch of projects.
    *
-   * Flow:
-   *   Subscribe to kind 3030 events on Nostr relays (time-paginated via `until`)
-   *   For each event, parse projectIdentifier from content
-   *   Check deny list
-   *  Fetch the project from the indexer to obtain trxId
-   *   Fetch the raw transaction hex and decode the OP_RETURN
-   *   Verify the OP_RETURN value matches the Nostr event ID
-   *   Add only verified projects to the signal
+   * Nostr-first verification flow:
+   *   Discover projects from the indexer (only the Bitcoin chain knows what
+   *     projects exist on-chain; there is no practical way to enumerate them
+   *     from Nostr without knowing the specific event IDs first).
+   *  For each project, fetch the founding transaction hex and decode the
+   *     OP_RETURN to obtain the blockchain-authoritative Nostr event ID.
+   *   Replace the indexer's nostrEventId with the OP_RETURN value whenever
+   *     it is successfully decoded — the indexer's value is never trusted blindly.
+   *  Calling relay.fetchListData() with the verified event IDs so that the
+   *     project content (profile, details) always comes from Nostr.
+   *
+   * Now a project whose indexer record carries a tampered nostrEventId will
+   * have it silently corrected to the real on-chain value, and the Nostr fetch
+   * will retrieve the genuine project event.  If OP_RETURN decoding fails for
+   * any reason (network error, tx not yet indexed) the original nostrEventId is
+   * used as a fallback so the page remains functional.
    */
   async fetchProjects(reset = false): Promise<void> {
     if (reset) {
-      this.nostrUntil = undefined;
-      this.nostrFetchComplete = false;
+      this.offset = -1000;
+      this.totalProjectsFetched = false;
+      this.totalItems = 0;
       this.projects.set([]);
     }
 
-    if (this.loading() || this.nostrFetchComplete) {
+    if (this.loading()) {
       return;
     }
 
@@ -425,124 +432,101 @@ export class IndexerService {
 
       this.loading.set(true);
       this.error.set(null);
+      let limit = this.LIMIT;
 
-      //Fetch kind 3030 events from Nostr relays
-      const nostrEvents = await this.relay.fetchNostrProjects(this.LIMIT, this.nostrUntil);
+      const isFirstLoad = this.offset === -1000;
 
-      if (nostrEvents.length === 0) {
-        this.nostrFetchComplete = true;
+      if (!isFirstLoad && this.offset < 0) {
+        limit = this.LIMIT + this.offset;
+        this.offset = 0;
+        this.totalProjectsFetched = true;
+      }
+
+      if (limit <= 0) {
+        this.loading.set(false);
+        this.totalProjectsFetched = true;
         return;
       }
 
-      // Mark complete if we received fewer events than requested (end of feed)
-      if (nostrEvents.length < this.LIMIT) {
-        this.nostrFetchComplete = true;
+      const params = new URLSearchParams();
+      params.append('limit', limit.toString());
+
+      if (!isFirstLoad && this.offset >= 0) {
+        params.append('offset', this.offset.toString());
       }
 
-      // Advance the time-based pagination cursor to just before the oldest event
-      const minTimestamp = nostrEvents.reduce(
-        (min, e) => Math.min(min, e.created_at ?? Infinity),
-        Infinity
-      );
-      if (minTimestamp !== Infinity) {
-        this.nostrUntil = minTimestamp - 1;
-      }
+      const url = `${this.indexerUrl}api/query/Angor/projects?${params.toString()}`;
+      const { data: response, headers } = await this.fetchJson<IndexedProject[]>(url);
 
-      // Verify each event in parallel
-      const verifiedProjects = await Promise.all(
-        nostrEvents.map(async (event): Promise<IndexedProject | null> => {
-          try {
-            if (!event.id) return null;
-
-            //  Parse project details from Nostr event content
-            let projectDetails: ProjectUpdate;
-            try {
-              projectDetails = JSON.parse(event.content) as ProjectUpdate;
-            } catch {
-              return null;
-            }
-
-            const projectIdentifier = projectDetails.projectIdentifier;
-            if (!projectIdentifier) return null;
-
-            //  Check deny list
-            if (await this.denyService.isEventDenied(projectIdentifier)) return null;
-
-            const alreadyLoaded = this.projects().some(
-              (p) => p.projectIdentifier === projectIdentifier
-            );
-            if (alreadyLoaded) return null;
-
-            //  Fetch project from indexer to get trxId and on-chain metadata
-            let indexerData: IndexedProject;
-            try {
-              const result = await this.fetchJson<IndexedProject>(
-                `${this.indexerUrl}api/query/Angor/projects/${projectIdentifier}`
-              );
-              indexerData = result.data;
-            } catch {
-              // Project not indexed yet or indexer error — skip silently
-              return null;
-            }
-
-            if (!indexerData?.trxId) return null;
-
-            //  Fetch raw transaction hex
-            let txHex: string | null = null;
-            try {
-              const result = await this.fetchJson<string>(
-                `${this.indexerUrl}api/query/transaction/${indexerData.trxId}/hex`
-              );
-              txHex = result.data ?? null;
-            } catch {
-              return null;
-            }
-
-            if (!txHex) return null;
-
-            //  Verify OP_RETURN embeds the Nostr event ID
-            const isVerified = this.verification.verifyEventInTransaction(txHex, event.id);
-            if (!isVerified) {
-              console.warn(
-                `[Angor] OP_RETURN mismatch for project ${projectIdentifier}. ` +
-                `Nostr event ID: ${event.id}, ` +
-                `OP_RETURN: ${this.verification.extractOpReturnEventId(txHex)}`
-              );
-              return null;
-            }
-
-            //  Build verified IndexedProject combining Nostr + indexer data
-            const project: IndexedProject = {
-              ...indexerData,
-              nostrEventId: event.id,  
-              details: projectDetails,
-              details_created_at: event.created_at,
-            };
-
-            // Kick off async profile fetch (result arrives via profileUpdates subject)
-            if (projectDetails.nostrPubKey) {
-              this.relay.fetchProfile([projectDetails.nostrPubKey]);
-            }
-
-            // Emit verified event so component subscriptions receive the update
-            this.relay.projectUpdates.next(event);
-
-            return project;
-          } catch (err) {
-            console.error('[Angor] Error processing Nostr event:', err);
-            return null;
+      if (Array.isArray(response) && response.length > 0) {
+        // Filter out denied projects
+        const filteredResponse: IndexedProject[] = [];
+        for (const item of response) {
+          const isDenied = await this.denyService.isEventDenied(item.projectIdentifier);
+          if (!isDenied) {
+            filteredResponse.push(item);
           }
-        })
-      );
+        }
 
-      // Add verified projects to the signal (deduplicate by projectIdentifier)
-      const newProjects = verifiedProjects.filter((p): p is IndexedProject => p !== null);
-      if (newProjects.length > 0) {
-        this.projects.update((existing) => {
-          const existingIds = new Set(existing.map((p) => p.projectIdentifier));
-          const unique = newProjects.filter((p) => !existingIds.has(p.projectIdentifier));
-          return [...existing, ...unique];
-        });
+        if (isFirstLoad) {
+          this.totalItems = parseInt(headers.get('pagination-total') || '0');
+          this.offset = Math.max(0, this.totalItems - limit);
+        } else {
+          this.offset = Math.max(0, this.offset - this.LIMIT);
+        }
+
+        if (this.offset === 0 && !isFirstLoad) {
+          this.totalProjectsFetched = true;
+        }
+
+        if (filteredResponse.length > 0) {
+          // Nostr-first verification 
+          // For each project, attempt to decode the OP_RETURN from its founding
+          // transaction and replace nostrEventId with the on-chain value.
+          await Promise.all(
+            filteredResponse.map(async (project) => {
+              if (!project.trxId) return;
+
+              const txHex = await this.fetchTxHex(project.trxId);
+              if (!txHex) return;
+
+              const embeddedId = this.verification.extractOpReturnEventId(txHex);
+              if (!embeddedId) return;
+
+              if (embeddedId !== project.nostrEventId?.toLowerCase()) {
+                console.warn(
+                  `[Angor] nostrEventId corrected for ${project.projectIdentifier}: ` +
+                  `indexer="${project.nostrEventId}" → op_return="${embeddedId}"`
+                );
+              }
+
+          
+              project.nostrEventId = embeddedId;
+            })
+          );
+
+          this.projects.update((existing) => {
+            const merged = [...existing];
+            const existingIds = new Set(existing.map(p => p.projectIdentifier));
+
+            filteredResponse.forEach((newProject) => {
+              if (!existingIds.has(newProject.projectIdentifier)) {
+                merged.push(newProject);
+                existingIds.add(newProject.projectIdentifier);
+              }
+            });
+
+            return merged;
+          });
+
+          // Fetch Nostr events by the OP_RETURN-verified event IDs
+          const verifiedEventIds = filteredResponse.map((project) => project.nostrEventId);
+          if (verifiedEventIds.length > 0) {
+            this.relay.fetchListData(verifiedEventIds);
+          }
+        }
+      } else {
+        this.totalProjectsFetched = true;
       }
     } catch (err) {
       await this.setErrorWithRetry(
@@ -561,12 +545,12 @@ export class IndexerService {
   /**
    * Fetches a single project by its identifier.
    *
-   * Uses OP_RETURN verification to ensure the Nostr event ID stored in the
-   * indexer is authentic: we decode the founding transaction's OP_RETURN and
-   * replace the indexer-supplied nostrEventId with the on-chain value.
+   * The OP_RETURN of the founding transaction is decoded to obtain the
+   * blockchain-authoritative Nostr event ID, replacing whatever value the
+   * indexer stored.  The project component then fetches the Nostr event using
+   * this verified ID, so the correct event is always displayed.
    */
   async fetchProject(id: string): Promise<IndexedProject | null> {
-
     await this.denyService.loadDenyList();
     if (await this.denyService.isEventDenied(id)) {
       this.error.set(`Project ${id} is not available.`);
@@ -587,25 +571,20 @@ export class IndexerService {
         return null;
       }
 
-      // Verify the Nostr event ID via OP_RETURN on the founding transaction
+      // Verify and correct the Nostr event ID via OP_RETURN
       if (project.trxId) {
         try {
-          const txResult = await this.fetchJson<string>(
-            `${this.indexerUrl}api/query/transaction/${project.trxId}/hex`
-          );
-          const txHex = txResult.data;
+          const txHex = await this.fetchTxHex(project.trxId);
 
           if (txHex) {
             const embeddedEventId = this.verification.extractOpReturnEventId(txHex);
             if (embeddedEventId) {
-              if (embeddedEventId !== project.nostrEventId.toLowerCase()) {
+              if (embeddedEventId !== project.nostrEventId?.toLowerCase()) {
                 console.warn(
-                  `[Angor] nostrEventId mismatch for project ${id}. ` +
-                  `Indexer: ${project.nostrEventId}, OP_RETURN: ${embeddedEventId}. ` +
-                  `Using OP_RETURN value as authoritative.`
+                  `[Angor] nostrEventId corrected for project ${id}: ` +
+                  `indexer="${project.nostrEventId}" → op_return="${embeddedEventId}"`
                 );
               }
-              // Replace with the on-chain-verified event ID
               project.nostrEventId = embeddedEventId;
             } else {
               console.warn(
@@ -635,9 +614,7 @@ export class IndexerService {
       this.loading.set(true);
       const url = `${this.indexerUrl}api/query/Angor/projects/${id}/stats`;
 
-
       const stats = (await this.fetchJson<ProjectStats>(url)).data;
-
 
       stats.amountInvested = Number(stats.amountInvested) || 0;
       stats.amountSpentSoFarByFounder = Number(stats.amountSpentSoFarByFounder) || 0;
@@ -758,16 +735,7 @@ export class IndexerService {
   }
 
   async getTransactionHex(txId: string): Promise<string | null> {
-    try {
-      const url = `${this.indexerUrl}api/query/transaction/${txId}/hex`;
-      const response = (await this.fetchJson<string>(url)).data;
-      return response !== undefined ? response : null;
-    } catch (err) {
-      await this.setErrorWithRetry(
-        err instanceof Error ? err.message : 'Failed to fetch transaction hex'
-      );
-      return null;
-    }
+    return this.fetchTxHex(txId);
   }
 
   async getBlocks(offset?: number, limit = 10): Promise<Block[]> {
@@ -831,39 +799,32 @@ export class IndexerService {
   }
 
   async loadMore(): Promise<void> {
-    if (!this.nostrFetchComplete) {
+    if (!this.totalProjectsFetched) {
       await this.fetchProjects();
     }
   }
 
   resetProjects(): void {
-    this.nostrUntil = undefined;
-    this.nostrFetchComplete = false;
+    this.offset = -1000;
+    this.totalProjectsFetched = false;
+    this.totalItems = 0;
     this.projects.set([]);
     this.fetchProjects(true);
   }
 
   isComplete(): boolean {
-    return this.nostrFetchComplete;
+    return this.totalProjectsFetched;
   }
 
-  /**
-   * Restores the Nostr pagination cursor (nostrUntil timestamp) when navigating
-   * back to the explore page
-   */
-  restoreOffset(until: number) {
-    this.nostrUntil = until > 0 ? until : undefined;
+  restoreOffset(offset: number) {
+    this.offset = offset;
   }
 
-  /**
-   * Returns the current Nostr pagination cursor as a number so ExploreStateService
-   */
   getCurrentOffset(): number {
-    return this.nostrUntil ?? 0;
+    return this.offset;
   }
 
   getTotalItems(): number {
-    // Total items is not available with Nostr-first pagination
-    return this.projects().length;
+    return this.totalItems;
   }
 }

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -494,11 +494,46 @@ export class IndexerService {
         return;
       }
 
-      // Step 3: Validate each project on-chain via the indexer (in parallel)
+      // Step 3: Validate each project on-chain via the indexer (in parallel).
+      // If we've previously validated a project, use the cached result
+      // instead of calling the indexer again — on-chain data is immutable.
       const validatedProjects = await Promise.all(
         candidateEvents.map(async ({ event, details }) => {
           try {
-            const url = `${this.indexerUrl}api/query/Angor/projects/${details.projectIdentifier}`;
+            const projectId = details.projectIdentifier;
+
+            // Hub mode filtering (can be checked before indexer call)
+            const nostrPubKey = details.nostrPubKey;
+            if (nostrPubKey && !this.hubConfig.shouldShowProject(nostrPubKey)) {
+              return null;
+            }
+
+            // Check validation cache first
+            const cached = this.verification.getCachedValidation(projectId);
+            if (cached) {
+              // Verify the cached event ID matches the Nostr event we discovered
+              if (cached.nostrEventId?.toLowerCase() !== event.id?.toLowerCase()) {
+                console.warn(
+                  `[Angor] Event ID mismatch for ${projectId}: ` +
+                  `nostr="${event.id}" vs cached="${cached.nostrEventId}" — skipping`
+                );
+                return null;
+              }
+
+              // Reconstruct the IndexedProject from cached on-chain data + Nostr details
+              return {
+                founderKey: cached.founderKey,
+                nostrEventId: event.id,
+                projectIdentifier: projectId,
+                createdOnBlock: cached.createdOnBlock,
+                trxId: cached.trxId,
+                details,
+                details_created_at: event.created_at,
+              } as IndexedProject;
+            }
+
+            // No cache — call the indexer to validate
+            const url = `${this.indexerUrl}api/query/Angor/projects/${projectId}`;
             const { data: indexerProject } = await this.fetchJson<IndexedProject>(url);
 
             if (!indexerProject) return null;
@@ -508,17 +543,19 @@ export class IndexerService {
             // the Nostr event ID we discovered.
             if (indexerProject.nostrEventId?.toLowerCase() !== event.id?.toLowerCase()) {
               console.warn(
-                `[Angor] Event ID mismatch for ${details.projectIdentifier}: ` +
+                `[Angor] Event ID mismatch for ${projectId}: ` +
                 `nostr="${event.id}" vs indexer="${indexerProject.nostrEventId}" — skipping`
               );
               return null;
             }
 
-            // Hub mode filtering
-            const nostrPubKey = details.nostrPubKey;
-            if (nostrPubKey && !this.hubConfig.shouldShowProject(nostrPubKey)) {
-              return null;
-            }
+            // Cache the validation result for future loads
+            this.verification.cacheValidation(projectId, {
+              founderKey: indexerProject.founderKey,
+              nostrEventId: indexerProject.nostrEventId,
+              trxId: indexerProject.trxId,
+              createdOnBlock: indexerProject.createdOnBlock,
+            });
 
             // Attach the Nostr-sourced details and event metadata
             indexerProject.nostrEventId = event.id;

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -98,9 +98,8 @@ export class IndexerService {
   private readonly LIMIT = 8;
   private indexerUrl = 'https://signet.angor.online/';
 
-  // Offset-based pagination
-  private offset = -1000;
-  private totalItems = 0;
+  // Nostr-first cursor-based pagination (using `until` timestamp)
+  private oldestEventTimestamp: number | undefined;
   private totalProjectsFetched = false;
 
   private relay = inject(RelayService);
@@ -413,27 +412,24 @@ export class IndexerService {
   }
 
   /**
-   * Fetches a paginated batch of projects.
+   * Fetches projects using a Nostr-first discovery approach.
    *
-   * Nostr-first verification flow:
-   *   1. Discover projects from the indexer (only the Bitcoin chain knows what
-   *      projects exist on-chain).
-   *   2. For each project, fetch the founding transaction hex and decode the
-   *      OP_RETURN to obtain the blockchain-authoritative Nostr event ID.
-   *   3. Replace the indexer's nostrEventId with the OP_RETURN value whenever
-   *      it is successfully decoded — the indexer's value is never trusted blindly.
-   *   4. Call relay.fetchListData() with the verified event IDs so that the
-   *      project content (profile, details) always comes from Nostr.
+   * Flow (matches the Angor desktop app):
+   *   1. Query Nostr relays for the latest kind 3030/30078 events.
+   *   2. Parse each event to extract projectIdentifier and nostrPubKey.
+   *   3. For each project, call the indexer to confirm it exists on-chain
+   *      and cross-check the Nostr event ID (the indexer stores the
+   *      OP_RETURN-embedded event ID from the founding transaction).
+   *   4. Only projects that pass validation are kept.
+   *   5. Profiles are fetched from Nostr for the validated projects.
    *
-   * A project whose indexer record carries a tampered nostrEventId will have it
-   * silently corrected to the real on-chain value. If OP_RETURN decoding fails
-   * for any reason the original nostrEventId is used as a fallback.
+   * Pagination uses Nostr's `until` parameter (timestamp cursor) instead
+   * of offset-based pagination against the indexer.
    */
   async fetchProjects(reset = false): Promise<void> {
     if (reset) {
-      this.offset = -1000;
+      this.oldestEventTimestamp = undefined;
       this.totalProjectsFetched = false;
-      this.totalItems = 0;
       this._allProjects.set([]);
     }
 
@@ -453,99 +449,120 @@ export class IndexerService {
 
       this.loading.set(true);
       this.error.set(null);
-      let limit = this.LIMIT;
 
-      const isFirstLoad = this.offset === -1000;
+      // Step 1: Discover projects from Nostr relays
+      const nostrEvents = await this.relay.fetchNostrProjects(
+        this.LIMIT,
+        this.oldestEventTimestamp
+      );
 
-      if (!isFirstLoad && this.offset < 0) {
-        limit = this.LIMIT + this.offset;
-        this.offset = 0;
-        this.totalProjectsFetched = true;
-      }
-
-      if (limit <= 0) {
-        this.loading.set(false);
+      if (nostrEvents.length === 0) {
         this.totalProjectsFetched = true;
         return;
       }
 
-      const params = new URLSearchParams();
-      params.append('limit', limit.toString());
+      // Update the pagination cursor to the oldest event's timestamp
+      // so the next call fetches older events.
+      const oldestEvent = nostrEvents.reduce(
+        (min, ev) => (ev.created_at! < min.created_at! ? ev : min),
+        nostrEvents[0]
+      );
+      this.oldestEventTimestamp = oldestEvent.created_at!;
 
-      if (!isFirstLoad && this.offset >= 0) {
-        params.append('offset', this.offset.toString());
+      // If we got fewer events than requested, we've reached the end
+      if (nostrEvents.length < this.LIMIT) {
+        this.totalProjectsFetched = true;
       }
 
-      const url = `${this.indexerUrl}api/query/Angor/projects?${params.toString()}`;
-      const { data: response, headers } = await this.fetchJson<IndexedProject[]>(url);
+      // Step 2: Parse events and deduplicate against already-loaded projects
+      const existingIds = new Set(this._allProjects().map(p => p.projectIdentifier));
+      const candidateEvents: { event: NDKEvent; details: ProjectUpdate }[] = [];
 
-      if (Array.isArray(response) && response.length > 0) {
-
-        if (isFirstLoad) {
-          this.totalItems = parseInt(headers.get('pagination-total') || '0');
-          this.offset = Math.max(0, this.totalItems - limit);
-        } else {
-          this.offset = Math.max(0, this.offset - this.LIMIT);
+      for (const event of nostrEvents) {
+        try {
+          const details: ProjectUpdate = JSON.parse(event.content);
+          if (!details.projectIdentifier) continue;
+          if (existingIds.has(details.projectIdentifier)) continue;
+          candidateEvents.push({ event, details });
+        } catch {
+          // Skip events with unparseable content
+          continue;
         }
+      }
 
-        if (this.offset === 0 && !isFirstLoad) {
-          this.totalProjectsFetched = true;
-        }
+      if (candidateEvents.length === 0) {
+        return;
+      }
 
-        // OP_RETURN verification: for each project, attempt to decode the
-        // OP_RETURN from its founding transaction and replace nostrEventId
-        // with the on-chain value. Results are cached in localStorage since
-        // Bitcoin transactions are immutable.
-        await Promise.all(
-          response.map(async (project) => {
-            if (!project.trxId) return;
+      // Step 3: Validate each project on-chain via the indexer (in parallel)
+      const validatedProjects = await Promise.all(
+        candidateEvents.map(async ({ event, details }) => {
+          try {
+            const url = `${this.indexerUrl}api/query/Angor/projects/${details.projectIdentifier}`;
+            const { data: indexerProject } = await this.fetchJson<IndexedProject>(url);
 
-            // Check cache first to avoid re-fetching the full tx hex
-            const cached = this.verification.getCachedEventId(project.trxId);
-            if (cached) {
-              project.nostrEventId = cached;
-              return;
-            }
+            if (!indexerProject) return null;
 
-            const txHex = await this.fetchTxHex(project.trxId);
-            if (!txHex) return;
-
-            const embeddedId = this.verification.extractOpReturnEventId(txHex);
-            if (!embeddedId) return;
-
-            if (embeddedId !== project.nostrEventId?.toLowerCase()) {
+            // Cross-check: the indexer's nostrEventId (derived from the
+            // OP_RETURN in the founding Bitcoin transaction) must match
+            // the Nostr event ID we discovered.
+            if (indexerProject.nostrEventId?.toLowerCase() !== event.id?.toLowerCase()) {
               console.warn(
-                `[Angor] nostrEventId corrected for ${project.projectIdentifier}: ` +
-                `indexer="${project.nostrEventId}" -> op_return="${embeddedId}"`
+                `[Angor] Event ID mismatch for ${details.projectIdentifier}: ` +
+                `nostr="${event.id}" vs indexer="${indexerProject.nostrEventId}" — skipping`
               );
+              return null;
             }
 
-            project.nostrEventId = embeddedId;
-            this.verification.cacheEventId(project.trxId, embeddedId);
-          })
-        );
-
-        this._allProjects.update((existing) => {
-          const merged = [...existing];
-          const existingIds = new Set(existing.map(p => p.projectIdentifier));
-
-          response.forEach((newProject) => {
-            if (!existingIds.has(newProject.projectIdentifier)) {
-              merged.push(newProject);
-              existingIds.add(newProject.projectIdentifier);
+            // Hub mode filtering
+            const nostrPubKey = details.nostrPubKey;
+            if (nostrPubKey && !this.hubConfig.shouldShowProject(nostrPubKey)) {
+              return null;
             }
-          });
 
-          return merged;
-        });
+            // Attach the Nostr-sourced details and event metadata
+            indexerProject.nostrEventId = event.id;
+            indexerProject.details = details;
+            indexerProject.details_created_at = event.created_at;
 
-        // Fetch Nostr events by the OP_RETURN-verified event IDs
-        const verifiedEventIds = response.map((project) => project.nostrEventId);
-        if (verifiedEventIds.length > 0) {
-          this.relay.fetchListData(verifiedEventIds);
+            return indexerProject;
+          } catch {
+            // Project not found on-chain or indexer unreachable — skip
+            return null;
+          }
+        })
+      );
+
+      const verified = validatedProjects.filter(
+        (p): p is IndexedProject => p !== null
+      );
+
+      if (verified.length === 0) {
+        return;
+      }
+
+      // Step 4: Add validated projects to the store
+      this._allProjects.update((existing) => {
+        const merged = [...existing];
+        const ids = new Set(existing.map(p => p.projectIdentifier));
+
+        for (const project of verified) {
+          if (!ids.has(project.projectIdentifier)) {
+            merged.push(project);
+            ids.add(project.projectIdentifier);
+          }
         }
-      } else {
-        this.totalProjectsFetched = true;
+
+        return merged;
+      });
+
+      // Step 5: Fetch profiles from Nostr for validated projects
+      const nostrPubKeys = verified
+        .map(p => p.details?.nostrPubKey)
+        .filter((k): k is string => !!k);
+
+      if (nostrPubKeys.length > 0) {
+        this.relay.fetchProfile(nostrPubKeys);
       }
     } catch (err) {
       await this.setErrorWithRetry(
@@ -835,9 +852,8 @@ export class IndexerService {
   }
 
   resetProjects(): void {
-    this.offset = -1000;
+    this.oldestEventTimestamp = undefined;
     this.totalProjectsFetched = false;
-    this.totalItems = 0;
     this._allProjects.set([]);
     this.fetchProjects(true);
   }
@@ -847,14 +863,17 @@ export class IndexerService {
   }
 
   restoreOffset(offset: number) {
-    this.offset = offset;
+    // For Nostr-first, offset is actually the `until` timestamp cursor
+    this.oldestEventTimestamp = offset || undefined;
   }
 
   getCurrentOffset(): number {
-    return this.offset;
+    // Returns the current pagination cursor (oldest event timestamp)
+    return this.oldestEventTimestamp ?? 0;
   }
 
   getTotalItems(): number {
-    return this.totalItems;
+    // With Nostr-first discovery, we don't know the total count upfront
+    return this._allProjects().length;
   }
 }

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -94,7 +94,7 @@ export interface NetworkStats {
 })
 export class IndexerService {
   private readonly LIMIT = 8;
-  private indexerUrl = 'https://tbtc.indexer.angor.io/';
+  private indexerUrl = 'https://signet.angor.online/';
 
   // Offset-based pagination (same as original — restores reliable project listing)
   private offset = -1000;
@@ -117,7 +117,6 @@ export class IndexerService {
       { url: 'https://electrs.angor.online/', isPrimary: false }
     ],
     testnet: [
-      { url: 'https://tbtc.indexer.angor.io/', isPrimary: false },
       { url: 'https://signet.angor.online/', isPrimary: true }
     ]
   });
@@ -166,7 +165,7 @@ export class IndexerService {
         { url: 'https://fulcrum.angor.online/', isPrimary: true },
         { url: 'https://electrs.angor.online/', isPrimary: false }
       ],
-      testnet: [{ url: 'https://tbtc.indexer.angor.io/', isPrimary: true }]
+      testnet: [{ url: 'https://signet.angor.online/', isPrimary: true }]
     };
   }
 
@@ -185,7 +184,7 @@ export class IndexerService {
     const networkIndexers = isMainnet ? config.mainnet : config.testnet;
     const primary = networkIndexers.find(indexer => indexer.isPrimary);
     return primary ? primary.url : networkIndexers[0]?.url ||
-      (isMainnet ? 'https://explorer.angor.io/' : 'https://tbtc.indexer.angor.io/');
+      (isMainnet ? 'https://explorer.angor.io/' : 'https://signet.angor.online/');
   }
 
   updateActiveIndexer(): void {

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -363,7 +363,10 @@ export class IndexerService {
 
     this._allProjects.update((projects) =>
       projects.map((project) => {
-        if (project.founderKey === pubkey) {
+        // Match by the project's Nostr pubkey (from details) since
+        // event.pubkey is a 64-char Nostr hex key, not the 66-char
+        // Bitcoin founderKey.
+        if (project.details?.nostrPubKey === pubkey) {
           if (
             !project.metadata_created_at ||
             event.created_at! > project.metadata_created_at
@@ -491,10 +494,18 @@ export class IndexerService {
 
         // OP_RETURN verification: for each project, attempt to decode the
         // OP_RETURN from its founding transaction and replace nostrEventId
-        // with the on-chain value.
+        // with the on-chain value. Results are cached in localStorage since
+        // Bitcoin transactions are immutable.
         await Promise.all(
           response.map(async (project) => {
             if (!project.trxId) return;
+
+            // Check cache first to avoid re-fetching the full tx hex
+            const cached = this.verification.getCachedEventId(project.trxId);
+            if (cached) {
+              project.nostrEventId = cached;
+              return;
+            }
 
             const txHex = await this.fetchTxHex(project.trxId);
             if (!txHex) return;
@@ -510,6 +521,7 @@ export class IndexerService {
             }
 
             project.nostrEventId = embeddedId;
+            this.verification.cacheEventId(project.trxId, embeddedId);
           })
         );
 
@@ -584,28 +596,35 @@ export class IndexerService {
 
       // Verify and correct the Nostr event ID via OP_RETURN
       if (project.trxId) {
-        try {
-          const txHex = await this.fetchTxHex(project.trxId);
+        // Check cache first
+        const cached = this.verification.getCachedEventId(project.trxId);
+        if (cached) {
+          project.nostrEventId = cached;
+        } else {
+          try {
+            const txHex = await this.fetchTxHex(project.trxId);
 
-          if (txHex) {
-            const embeddedEventId = this.verification.extractOpReturnEventId(txHex);
-            if (embeddedEventId) {
-              if (embeddedEventId !== project.nostrEventId?.toLowerCase()) {
+            if (txHex) {
+              const embeddedEventId = this.verification.extractOpReturnEventId(txHex);
+              if (embeddedEventId) {
+                if (embeddedEventId !== project.nostrEventId?.toLowerCase()) {
+                  console.warn(
+                    `[Angor] nostrEventId corrected for project ${id}: ` +
+                    `indexer="${project.nostrEventId}" -> op_return="${embeddedEventId}"`
+                  );
+                }
+                project.nostrEventId = embeddedEventId;
+                this.verification.cacheEventId(project.trxId, embeddedEventId);
+              } else {
                 console.warn(
-                  `[Angor] nostrEventId corrected for project ${id}: ` +
-                  `indexer="${project.nostrEventId}" -> op_return="${embeddedEventId}"`
+                  `[Angor] No OP_RETURN found in transaction ${project.trxId} for project ${id}`
                 );
               }
-              project.nostrEventId = embeddedEventId;
-            } else {
-              console.warn(
-                `[Angor] No OP_RETURN found in transaction ${project.trxId} for project ${id}`
-              );
             }
+          } catch (err) {
+            // Fall back to the indexer-supplied nostrEventId
+            console.warn(`[Angor] Could not verify OP_RETURN for project ${id}:`, err);
           }
-        } catch (err) {
-          // Fall back to the indexer-supplied nostrEventId
-          console.warn(`[Angor] Could not verify OP_RETURN for project ${id}:`, err);
         }
       }
 

--- a/src/app/services/nostr-project-verification.service.ts
+++ b/src/app/services/nostr-project-verification.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+
+export interface VerificationResult {
+  verified: boolean;
+  eventId: string;
+  projectIdentifier: string;
+  reason?: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NostrProjectVerificationService {
+  /**
+   * Extracts the embedded Nostr event ID from a raw Bitcoin transaction hex.
+   *
+   * Angor embeds the Nostr event ID in an OP_RETURN output with the script:
+   *   6a (OP_RETURN opcode) + 20 (PUSH 32 bytes) + <32-byte event ID>
+   *
+   * @param txHex 
+   * @returns 
+   */
+  extractOpReturnEventId(txHex: string): string | null {
+    if (!txHex) return null;
+
+    // Scan for OP_RETURN pattern
+    const match = txHex.match(/6a20([0-9a-f]{64})/i);
+    return match ? match[1].toLowerCase() : null;
+  }
+
+  /**
+   * Verifies that a transaction's OP_RETURN data matches the expected Nostr event ID.
+   *
+   * @param txHex 
+   * @param expectedEventId 
+   * @returns 
+   */
+  verifyEventInTransaction(txHex: string, expectedEventId: string): boolean {
+    const embedded = this.extractOpReturnEventId(txHex);
+    if (!embedded) return false;
+    return embedded === expectedEventId.toLowerCase();
+  }
+}

--- a/src/app/services/nostr-project-verification.service.ts
+++ b/src/app/services/nostr-project-verification.service.ts
@@ -7,18 +7,41 @@ export interface VerificationResult {
   reason?: string;
 }
 
+const OPRETURN_CACHE_KEY = 'angor_opreturn_cache';
+
 @Injectable({
   providedIn: 'root',
 })
 export class NostrProjectVerificationService {
+  private memoryCache = new Map<string, string>();
+
+  constructor() {
+    this.loadCache();
+  }
+
+  /**
+   * Returns a cached OP_RETURN event ID for the given transaction, or null
+   * if none is cached. Bitcoin transactions are immutable, so a cached
+   * result is always valid.
+   */
+  getCachedEventId(txId: string): string | null {
+    return this.memoryCache.get(txId) ?? null;
+  }
+
+  /**
+   * Stores an OP_RETURN event ID for a transaction in both the in-memory
+   * cache and localStorage for persistence across page loads.
+   */
+  cacheEventId(txId: string, eventId: string): void {
+    this.memoryCache.set(txId, eventId);
+    this.saveCache();
+  }
+
   /**
    * Extracts the embedded Nostr event ID from a raw Bitcoin transaction hex.
    *
    * Angor embeds the Nostr event ID in an OP_RETURN output with the script:
    *   6a (OP_RETURN opcode) + 20 (PUSH 32 bytes) + <32-byte event ID>
-   *
-   * @param txHex 
-   * @returns 
    */
   extractOpReturnEventId(txHex: string): string | null {
     if (!txHex) return null;
@@ -30,14 +53,37 @@ export class NostrProjectVerificationService {
 
   /**
    * Verifies that a transaction's OP_RETURN data matches the expected Nostr event ID.
-   *
-   * @param txHex 
-   * @param expectedEventId 
-   * @returns 
    */
   verifyEventInTransaction(txHex: string, expectedEventId: string): boolean {
     const embedded = this.extractOpReturnEventId(txHex);
     if (!embedded) return false;
     return embedded === expectedEventId.toLowerCase();
+  }
+
+  private loadCache(): void {
+    try {
+      const raw = localStorage.getItem(OPRETURN_CACHE_KEY);
+      if (raw) {
+        const entries: Record<string, string> = JSON.parse(raw);
+        for (const [txId, eventId] of Object.entries(entries)) {
+          this.memoryCache.set(txId, eventId);
+        }
+      }
+    } catch {
+      // Corrupted cache — start fresh
+      localStorage.removeItem(OPRETURN_CACHE_KEY);
+    }
+  }
+
+  private saveCache(): void {
+    try {
+      const obj: Record<string, string> = {};
+      this.memoryCache.forEach((eventId, txId) => {
+        obj[txId] = eventId;
+      });
+      localStorage.setItem(OPRETURN_CACHE_KEY, JSON.stringify(obj));
+    } catch {
+      // localStorage full or unavailable — cache still works in-memory
+    }
   }
 }

--- a/src/app/services/nostr-project-verification.service.ts
+++ b/src/app/services/nostr-project-verification.service.ts
@@ -7,17 +7,33 @@ export interface VerificationResult {
   reason?: string;
 }
 
+/**
+ * On-chain project data cached after indexer validation.
+ * These fields come from the Bitcoin blockchain and never change.
+ */
+export interface CachedProjectValidation {
+  founderKey: string;
+  nostrEventId: string;
+  trxId: string;
+  createdOnBlock: number;
+}
+
 const OPRETURN_CACHE_KEY = 'angor_opreturn_cache';
+const PROJECT_VALIDATION_CACHE_KEY = 'angor_project_validation_cache';
 
 @Injectable({
   providedIn: 'root',
 })
 export class NostrProjectVerificationService {
   private memoryCache = new Map<string, string>();
+  private projectCache = new Map<string, CachedProjectValidation>();
 
   constructor() {
     this.loadCache();
+    this.loadProjectCache();
   }
+
+  // --- OP_RETURN cache (keyed by txId) ---
 
   /**
    * Returns a cached OP_RETURN event ID for the given transaction, or null
@@ -35,6 +51,26 @@ export class NostrProjectVerificationService {
   cacheEventId(txId: string, eventId: string): void {
     this.memoryCache.set(txId, eventId);
     this.saveCache();
+  }
+
+  // --- Project validation cache (keyed by projectIdentifier) ---
+
+  /**
+   * Returns cached on-chain data for a project that was previously
+   * validated against the indexer, or null if not cached.
+   */
+  getCachedValidation(projectIdentifier: string): CachedProjectValidation | null {
+    return this.projectCache.get(projectIdentifier) ?? null;
+  }
+
+  /**
+   * Caches the on-chain data for a validated project. Since Bitcoin
+   * transactions are immutable, a project's founderKey, trxId,
+   * createdOnBlock, and nostrEventId (from OP_RETURN) never change.
+   */
+  cacheValidation(projectIdentifier: string, data: CachedProjectValidation): void {
+    this.projectCache.set(projectIdentifier, data);
+    this.saveProjectCache();
   }
 
   /**
@@ -60,6 +96,8 @@ export class NostrProjectVerificationService {
     return embedded === expectedEventId.toLowerCase();
   }
 
+  // --- OP_RETURN cache persistence ---
+
   private loadCache(): void {
     try {
       const raw = localStorage.getItem(OPRETURN_CACHE_KEY);
@@ -82,6 +120,34 @@ export class NostrProjectVerificationService {
         obj[txId] = eventId;
       });
       localStorage.setItem(OPRETURN_CACHE_KEY, JSON.stringify(obj));
+    } catch {
+      // localStorage full or unavailable — cache still works in-memory
+    }
+  }
+
+  // --- Project validation cache persistence ---
+
+  private loadProjectCache(): void {
+    try {
+      const raw = localStorage.getItem(PROJECT_VALIDATION_CACHE_KEY);
+      if (raw) {
+        const entries: Record<string, CachedProjectValidation> = JSON.parse(raw);
+        for (const [id, data] of Object.entries(entries)) {
+          this.projectCache.set(id, data);
+        }
+      }
+    } catch {
+      localStorage.removeItem(PROJECT_VALIDATION_CACHE_KEY);
+    }
+  }
+
+  private saveProjectCache(): void {
+    try {
+      const obj: Record<string, CachedProjectValidation> = {};
+      this.projectCache.forEach((data, id) => {
+        obj[id] = data;
+      });
+      localStorage.setItem(PROJECT_VALIDATION_CACHE_KEY, JSON.stringify(obj));
     } catch {
       // localStorage full or unavailable — cache still works in-memory
     }

--- a/src/app/services/relay.service.ts
+++ b/src/app/services/relay.service.ts
@@ -280,4 +280,33 @@ export class RelayService {
   public getDefaultRelays(): string[] {
     return [...this.defaultRelays];
   }
+
+  /**
+   * Fetches kind 3030 (Angor project announcement) events directly from Nostr relays
+   * without filtering by ID. Used for Nostr-first project discovery.
+   *
+   * @param limit 
+   * @param until
+   * @returns 
+   */
+  async fetchNostrProjects(limit: number, until?: number): Promise<NDKEvent[]> {
+    try {
+      const ndk = await this.ensureConnected();
+
+      const filter: { kinds: number[]; limit: number; until?: number } = {
+        kinds: [3030],
+        limit,
+      };
+
+      if (until !== undefined) {
+        filter.until = until;
+      }
+
+      const events = await ndk.fetchEvents(filter);
+      return Array.from(events);
+    } catch (error) {
+      console.error('Error fetching Nostr projects (kind 3030):', error);
+      return [];
+    }
+  }
 }

--- a/src/app/services/relay.service.ts
+++ b/src/app/services/relay.service.ts
@@ -293,8 +293,9 @@ export class RelayService {
     try {
       const ndk = await this.ensureConnected();
 
+      // Include both Angor project event kinds (mainnet uses 30078, testnet/newer uses 3030)
       const filter: { kinds: number[]; limit: number; until?: number } = {
-        kinds: [3030],
+        kinds: [3030, 30078],
         limit,
       };
 
@@ -302,10 +303,28 @@ export class RelayService {
         filter.until = until;
       }
 
-      const events = await ndk.fetchEvents(filter);
-      return Array.from(events);
+      // Use subscribe + EOSE rather than fetchEvents
+      const collected: NDKEvent[] = [];
+
+      const sub = ndk.subscribe(filter);
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, 8000);
+
+        sub.on('event', (event: NDKEvent) => {
+          collected.push(event);
+        });
+
+        sub.on('eose', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+
+      console.log(`[Angor] fetchNostrProjects: received ${collected.length} events`);
+      return collected;
     } catch (error) {
-      console.error('Error fetching Nostr projects (kind 3030):', error);
+      console.error('Error fetching Nostr projects (kind 3030/30078):', error);
       return [];
     }
   }


### PR DESCRIPTION
## Summary                                                                                  
                                                            
  - Replaces the indexer-first project discovery flow with a Nostr-first approach: kind
  3030 events are fetched directly from Nostr relays, and each event is cryptographically
  verified against the Bitcoin blockchain before being displayed
  - Introduces NostrProjectVerificationService to decode OP_RETURN data from raw
  transaction hex and compare it against the Nostr event ID
  - Replaces offset-based pagination with time-based pagination unaligned
  with how Nostr relays serve events

 ## How it works

  Before: The indexer was the source of truth. It returned a nostrEventId that was trusted
  blindly, then used to fetch project data from Nostr. The trxId field existed on every
  project but was never used for anything.

  ## Now:
  1. Kind 3030 events are fetched from Nostr relays independently (no ID filter from the
  indexer)
  2. For each event, the projectIdentifier is extracted from the event content
  3. The indexer is queried for that project to obtain trxId
  4. The founding transaction hex is fetched and the OP_RETURN output is decoded
  (6a20<32-byte-event-id>)
  5. The decoded event ID is compared against the Nostr event's id — projects that fail
  this check are silently dropped and never shown
  6. For single-project views (/project/:id), the indexer-supplied nostrEventId is replaced
   with the OP_RETURN-verified value before any Nostr fetch is made

 
  ## Test plan

  - Explore page loads and displays only verified projects
  - Infinite scroll continues to load more projects via until-based pagination
  - Single project page (/project/:id) loads correctly with verified Nostr event ID
  - Projects with a mismatched OP_RETURN are not displayed; an Angor OP_RETURN mismatch
  warning appears in the browser console
  - Projects where the indexer's nostrEventId differs from the OP_RETURN value log a
  warning and use the on-chain value
  - Deny list filtering still works correctly in the new flow
  - Switching between mainnet and testnet resets and re-fetches correctly

<img width="1512" height="846" alt="Screenshot 2026-02-26 at 12 15 02 PM" src="https://github.com/user-attachments/assets/a9491224-e57d-4bcf-acab-407a32dcda59" />


<img width="1420" height="838" alt="Screenshot 2026-02-26 at 12 15 23 PM" src="https://github.com/user-attachments/assets/f8c537ae-11fc-410e-a085-842c691d20b3" />

