### PR TITLE
feat: add project search by ID and fix project detail reactivity

### DIFF
--- a/src/app/pages/explore/explore.component.html
+++ b/src/app/pages/explore/explore.component.html
@@ -37,17 +37,24 @@
       <div class="relative flex-grow">
         <input
           type="text"
-          placeholder="Search projects..."
+          placeholder="Search projects or enter project ID (angor1...)..."
           class="w-full h-10 pl-10 pr-10 rounded-lg bg-surface-ground focus:outline-none focus:bg-surface-ground text-sm text-text placeholder-text-secondary hover:bg-surface-hover"
           [value]="searchTerm()"
           (input)="onSearchInput($event)"
-          aria-label="Search projects"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search projects or enter project ID"
         />
         <span
           class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-base"
           >search</span
         >
-        @if (searchTerm()) {
+        @if (isSearchingProject()) {
+          <span
+            class="absolute right-3 top-1/2 -translate-y-1/2 text-accent animate-spin"
+          >
+            <span class="material-icons text-base">autorenew</span>
+          </span>
+        } @else if (searchTerm()) {
           <button
             class="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text transition-colors duration-300"
             (click)="clearSearch()"
@@ -169,6 +176,15 @@
         }
       </div>
     </div>
+
+    @if (searchError()) {
+      <div class="px-3 pb-3">
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-warning/10 text-warning text-sm">
+          <span class="material-icons text-base">error_outline</span>
+          {{ searchError() }}
+        </div>
+      </div>
+    }
 
     
     @if (showMobileFilters) {

--- a/src/app/pages/explore/explore.component.ts
+++ b/src/app/pages/explore/explore.component.ts
@@ -150,6 +150,11 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
       distinctUntilChanged()
     ).subscribe((term) => {
       this.searchTerm.set(term);
+
+      // Auto-trigger project lookup when a project ID is pasted/typed
+      if (term.trim().startsWith('angor1')) {
+        this.lookupProjectById(term.trim());
+      }
     });
 
 
@@ -542,14 +547,60 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
     else this.showSortDropdown = false;
   }
 
+  searchError = signal<string>('');
+  isSearchingProject = signal<boolean>(false);
+
   onSearchInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     this.searchSubject.next(input.value);
+    this.searchError.set('');
+  }
+
+  async onSearchSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    const term = this.searchTerm().trim();
+    if (!term) return;
+
+    if (!term.startsWith('angor1')) {
+      return;
+    }
+
+    await this.lookupProjectById(term);
+  }
+
+  private async lookupProjectById(term: string): Promise<void> {
+    if (this.isSearchingProject()) return;
+
+    this.searchError.set('');
+    this.isSearchingProject.set(true);
+
+    try {
+      // First check if we already have it loaded
+      const project = this.indexer.getProject(term);
+      if (project) {
+        this.router.navigate(['/project', term]);
+        return;
+      }
+
+      // Fetch from blockchain
+      const fetched = await this.indexer.fetchProject(term);
+      if (fetched) {
+        this.router.navigate(['/project', term]);
+      } else {
+        this.searchError.set('Project not found. Please check the project ID and try again.');
+      }
+    } catch (error) {
+      console.error('Error searching for project:', error);
+      this.searchError.set('Failed to look up project. Please try again.');
+    } finally {
+      this.isSearchingProject.set(false);
+    }
   }
 
   clearSearch(): void {
     this.searchTerm.set('');
     this.searchSubject.next('');
+    this.searchError.set('');
   }
 
   getRandomColor(seed: string): string {

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -494,9 +494,10 @@ export class ProjectComponent implements OnInit, OnDestroy {
         this.loadOnChainStats();
 
         if (!projectData.details) {
-
-          this.relay.fetchData([projectData.nostrEventId]);
-
+          // Guard: only fetch from Nostr if we have a valid event ID
+          if (projectData.nostrEventId) {
+            this.relay.fetchData([projectData.nostrEventId]);
+          }
         } else {
           this.user = new NDKUser({
             pubkey: projectData.details.nostrPubKey,
@@ -526,14 +527,22 @@ export class ProjectComponent implements OnInit, OnDestroy {
             }
 
             this.projectEvent = event;
-            projectData!.details = details;
 
+            // Update through signal to avoid closure divergence
+            const current = this.project()!;
+            current.details = details;
+            current.details_created_at = event.created_at;
 
             this.user = new NDKUser({
-              pubkey: projectData!.details.nostrPubKey,
+              pubkey: details.nostrPubKey,
               relayUrls: this.relay.relayUrls(),
             });
 
+            // Trigger signal reactivity so the template updates
+            this.project.set({ ...current });
+
+            // Re-trigger stats now that details are available
+            this.loadOnChainStats();
 
             this.relay.fetchProfile([details.nostrPubKey]);
           }
@@ -547,7 +556,8 @@ export class ProjectComponent implements OnInit, OnDestroy {
 
           const update: NDKUserProfile = JSON.parse(event.content);
 
-          if (event.pubkey == projectData!.details?.nostrPubKey) {
+          const current = this.project();
+          if (event.pubkey == current?.details?.nostrPubKey) {
             if (this.profileEvent) {
               if (this.profileEvent.created_at! > event.created_at!) {
                 {
@@ -557,13 +567,16 @@ export class ProjectComponent implements OnInit, OnDestroy {
             }
 
             this.profileEvent = event;
-            projectData!.metadata = update;
+            current.metadata = update;
 
             this.title.setTitle(update.name);
 
-            projectData!.externalIdentities =
+            current.externalIdentities =
               this.utils.getExternalIdentities(event);
-            projectData!.externalIdentities_created_at = event.created_at;
+            current.externalIdentities_created_at = event.created_at;
+
+            // Trigger signal reactivity so the template updates
+            this.project.set({ ...current });
           }
         });
 
@@ -607,6 +620,9 @@ export class ProjectComponent implements OnInit, OnDestroy {
           } else {
             console.warn('Unknown tag:', tag);
           }
+
+          // Trigger signal reactivity so the template updates
+          this.project.set({ ...project });
         });
 
         this.subscriptions.push(projectSub, profileSub, contentSub);


### PR DESCRIPTION
## Summary

- **Project search by ID**: The search box on the explore page now auto-detects project identifiers (starting with `angor1`) and navigates directly to the project detail page after looking it up on-chain. Shows a loading spinner during lookup and an error message if not found.
- **Fix project detail reactivity**: Subscriptions in the project component now read/write through `this.project()` signal instead of a stale closure variable, fixing the issue where metadata (banner, description) and stats only appeared after a hard refresh.
- **Guard empty nostrEventId**: Prevents calling `relay.fetchData` with an empty string when the OP_RETURN doesn't contain a Nostr event ID.
- **Re-trigger stats after details arrive**: `loadOnChainStats()` is now called again after the kind 3030 event provides full project details.
