### PR TITLE
feat: add download page and wire App nav to internal /app route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { ProjectComponent } from './pages/project/project.component';
 import { SettingsComponent } from './pages/settings/settings.component';
 import { ReportComponent } from './pages/report/report.component';
 import { AdminComponent } from './pages/admin/admin.component';
+import { DownloadComponent } from './pages/download/download.component';
 
 export const routes: Routes = [
   {
@@ -42,6 +43,12 @@ export const routes: Routes = [
     component: AdminComponent,
     title: 'Admin - Manage Deny Lists',
     data: { animation: 'AdminPage' } 
+  },
+  {
+    path: 'app',
+    component: DownloadComponent,
+    title: 'Download Angor',
+    data: { animation: 'DownloadPage' } 
   },
   {
     path: '**',

--- a/src/app/components/header.component.ts
+++ b/src/app/components/header.component.ts
@@ -94,7 +94,7 @@ import { ThemeService } from '../services/theme.service';
             <a routerLink="/explore" routerLinkActive="bg-surface-hover text-accent" class="px-4 py-2 rounded-lg text-sm font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="closeAllMenus()">
               Projects
             </a>
-            <a href="https://angor.io/app" target="_blank" rel="noopener noreferrer" class="px-4 py-2 rounded-lg text-sm font-medium text-header-text hover:bg-surface-hover transition-colors">
+            <a routerLink="/app" routerLinkActive="bg-surface-hover text-accent" class="px-4 py-2 rounded-lg text-sm font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="closeAllMenus()">
               App
             </a>
             <a href="https://profile.angor.io/angor-profile/" target="_blank" rel="noopener noreferrer" class="px-4 py-2 rounded-lg text-sm font-medium text-header-text hover:bg-surface-hover transition-colors">
@@ -139,7 +139,7 @@ import { ThemeService } from '../services/theme.service';
             <a routerLink="/explore" routerLinkActive="bg-surface-hover text-accent" class="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="toggleMobileMenu()">
               Projects
             </a>
-            <a href="https://angor.io/app" target="_blank" rel="noopener noreferrer" class="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="toggleMobileMenu()">
+            <a routerLink="/app" routerLinkActive="bg-surface-hover text-accent" class="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="toggleMobileMenu()">
               App
             </a>
             <a href="https://profile.angor.io/angor-profile/" target="_blank" rel="noopener noreferrer" class="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium text-header-text hover:bg-surface-hover transition-colors" (click)="toggleMobileMenu()">

--- a/src/app/pages/download/download.component.html
+++ b/src/app/pages/download/download.component.html
@@ -1,0 +1,53 @@
+<section class="download-section">
+  <!-- Background pattern -->
+  <div class="download-background"></div>
+
+  <div class="download-content">
+    <!-- App icon -->
+    <img src="/images/app-icon-dark-mode.png" alt="Angor" class="download-logo" />
+
+    <!-- Title -->
+    <h1 class="download-headline">
+      Download <span class="emphasis">Angor</span>
+    </h1>
+
+    <!-- Security advisory -->
+    <div class="security-badge">
+      <span class="material-icons security-icon">verified_user</span>
+      <span>We advise downloading the app for the best security</span>
+    </div>
+
+    <!-- Primary download button -->
+    <a [href]="primaryDownloadUrl()" target="_blank" rel="noopener noreferrer" class="btn-download">
+      <span class="material-icons">download</span>
+      <span>Download for {{ detectedPlatform() }}</span>
+    </a>
+
+    <!-- Alternative platforms -->
+    <div class="alt-platforms">
+      <p class="alt-label">Not on {{ detectedPlatform() }}?</p>
+      <div class="alt-links">
+        @for (platform of alternativePlatforms(); track platform.name) {
+          <a [href]="platform.url" target="_blank" rel="noopener noreferrer" class="alt-link">
+            {{ platform.name }}
+          </a>
+        }
+      </div>
+    </div>
+
+    <!-- Android / Mobile section -->
+    <div class="mobile-section">
+      <h2 class="mobile-heading">Android</h2>
+      <div class="mobile-links">
+        <a href="https://github.com/block-core/angor/releases" target="_blank" rel="noopener noreferrer" class="btn-secondary-download">
+          <span class="material-icons">code</span>
+          GitHub Releases
+        </a>
+        <a href="https://zapstore.dev" target="_blank" rel="noopener noreferrer" class="btn-secondary-download">
+          <span class="material-icons">store</span>
+          Zapstore
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/app/pages/download/download.component.ts
+++ b/src/app/pages/download/download.component.ts
@@ -1,0 +1,241 @@
+import { Component, OnInit, inject, signal, computed, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { TitleService } from '../../services/title.service';
+import { MetaService } from '../../services/meta.service';
+
+interface PlatformLink {
+  name: string;
+  url: string;
+}
+
+@Component({
+  selector: 'app-download',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './download.component.html',
+  styles: [`
+    .download-section {
+      position: relative;
+      min-height: calc(100vh - 64px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      background-color: var(--surface-ground);
+    }
+
+    .download-background {
+      position: absolute;
+      inset: 0;
+      background-image: url('/assets/images/hero-bg-pattern.svg');
+      background-repeat: repeat;
+      background-size: 164px 164px;
+      opacity: 0.05;
+    }
+
+    .download-content {
+      position: relative;
+      z-index: 10;
+      text-align: center;
+      padding: 2rem;
+      max-width: 600px;
+      width: 100%;
+    }
+
+    .download-logo {
+      width: 96px;
+      height: 96px;
+      margin: 0 auto 2rem;
+      filter: drop-shadow(0 10px 30px rgba(75, 124, 90, 0.3));
+    }
+
+    .download-headline {
+      font-size: clamp(2.5rem, 5vw, 3.5rem);
+      font-weight: 700;
+      line-height: 1.2;
+      margin-bottom: 2rem;
+      color: var(--text);
+    }
+
+    .download-headline .emphasis {
+      color: var(--accent);
+      font-style: italic;
+    }
+
+    .security-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.75rem;
+      background-color: rgba(75, 124, 90, 0.15);
+      border: 1px solid rgba(75, 124, 90, 0.3);
+      color: var(--accent);
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 2rem;
+    }
+
+    .security-icon {
+      font-size: 1.25rem;
+    }
+
+    .btn-download {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 1rem 2.5rem;
+      border-radius: 0.75rem;
+      font-size: 1.125rem;
+      font-weight: 600;
+      background-color: var(--accent);
+      color: white;
+      transition: all 0.3s ease;
+      text-decoration: none;
+      margin-bottom: 1.5rem;
+    }
+
+    .btn-download:hover {
+      background-color: #3d6448;
+      transform: translateY(-2px);
+      box-shadow: 0 10px 25px rgba(75, 124, 90, 0.3);
+    }
+
+    .alt-platforms {
+      margin-bottom: 3rem;
+    }
+
+    .alt-label {
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .alt-links {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+    }
+
+    .alt-link {
+      color: var(--text);
+      font-size: 0.875rem;
+      text-decoration: underline;
+      transition: color 0.2s;
+    }
+
+    .alt-link:hover {
+      color: var(--accent);
+    }
+
+    .mobile-section {
+      border-top: 1px solid var(--border);
+      padding-top: 2rem;
+    }
+
+    .mobile-heading {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 1rem;
+    }
+
+    .mobile-links {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn-secondary-download {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.75rem;
+      font-size: 0.95rem;
+      font-weight: 500;
+      background-color: var(--surface-card);
+      color: var(--text);
+      border: 1px solid var(--border);
+      transition: all 0.3s ease;
+      text-decoration: none;
+    }
+
+    .btn-secondary-download:hover {
+      background-color: var(--surface-hover);
+      transform: translateY(-2px);
+      box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+    }
+
+    @media (max-width: 768px) {
+      .download-logo {
+        width: 72px;
+        height: 72px;
+        margin-bottom: 1.5rem;
+      }
+
+      .download-headline {
+        font-size: 2rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .mobile-links {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .btn-secondary-download {
+        width: 100%;
+        max-width: 280px;
+        justify-content: center;
+      }
+    }
+  `]
+})
+export class DownloadComponent implements OnInit {
+  private titleService = inject(TitleService);
+  private metaService = inject(MetaService);
+  private platformId = inject(PLATFORM_ID);
+
+  private allPlatforms: PlatformLink[] = [
+    { name: 'Windows', url: 'https://github.com/block-core/angor/releases' },
+    { name: 'macOS', url: 'https://github.com/block-core/angor/releases' },
+    { name: 'Linux', url: 'https://github.com/block-core/angor/releases' },
+  ];
+
+  detectedPlatform = signal<string>('Windows');
+
+  primaryDownloadUrl = computed(() => {
+    const platform = this.allPlatforms.find(p => p.name === this.detectedPlatform());
+    return platform?.url ?? 'https://github.com/block-core/angor/releases';
+  });
+
+  alternativePlatforms = computed(() =>
+    this.allPlatforms.filter(p => p.name !== this.detectedPlatform())
+  );
+
+  ngOnInit(): void {
+    this.titleService.setTitle('Download Angor');
+    this.metaService.updateMetaTags({
+      title: 'Download Angor',
+      description: 'Download the Angor app for the best security. Available for Windows, macOS, Linux, and Android.',
+      image: 'https://angor.io/assets/angor-hub-social.png',
+      url: 'https://angor.io/app'
+    });
+
+    if (isPlatformBrowser(this.platformId)) {
+      this.detectedPlatform.set(this.detectOS());
+    }
+  }
+
+  private detectOS(): string {
+    const ua = navigator.userAgent.toLowerCase();
+    const platform = navigator.platform?.toLowerCase() ?? '';
+
+    if (ua.includes('win') || platform.includes('win')) return 'Windows';
+    if (ua.includes('mac') || platform.includes('mac')) return 'macOS';
+    if (ua.includes('linux') || platform.includes('linux')) return 'Linux';
+    return 'Windows';
+  }
+}

--- a/src/app/pages/explore/explore.component.html
+++ b/src/app/pages/explore/explore.component.html
@@ -37,17 +37,24 @@
       <div class="relative flex-grow">
         <input
           type="text"
-          placeholder="Search projects..."
+          placeholder="Search projects or enter project ID (angor1...)..."
           class="w-full h-10 pl-10 pr-10 rounded-lg bg-surface-ground focus:outline-none focus:bg-surface-ground text-sm text-text placeholder-text-secondary hover:bg-surface-hover"
           [value]="searchTerm()"
           (input)="onSearchInput($event)"
-          aria-label="Search projects"
+          (keydown.enter)="onSearchSubmit($event)"
+          aria-label="Search projects or enter project ID"
         />
         <span
           class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-base"
           >search</span
         >
-        @if (searchTerm()) {
+        @if (isSearchingProject()) {
+          <span
+            class="absolute right-3 top-1/2 -translate-y-1/2 text-accent animate-spin"
+          >
+            <span class="material-icons text-base">autorenew</span>
+          </span>
+        } @else if (searchTerm()) {
           <button
             class="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text transition-colors duration-300"
             (click)="clearSearch()"
@@ -169,6 +176,15 @@
         }
       </div>
     </div>
+
+    @if (searchError()) {
+      <div class="px-3 pb-3">
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-warning/10 text-warning text-sm">
+          <span class="material-icons text-base">error_outline</span>
+          {{ searchError() }}
+        </div>
+      </div>
+    }
 
     
     @if (showMobileFilters) {

--- a/src/app/pages/explore/explore.component.ts
+++ b/src/app/pages/explore/explore.component.ts
@@ -150,6 +150,11 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
       distinctUntilChanged()
     ).subscribe((term) => {
       this.searchTerm.set(term);
+
+      // Auto-trigger project lookup when a project ID is pasted/typed
+      if (term.trim().startsWith('angor1')) {
+        this.lookupProjectById(term.trim());
+      }
     });
 
 
@@ -542,14 +547,60 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
     else this.showSortDropdown = false;
   }
 
+  searchError = signal<string>('');
+  isSearchingProject = signal<boolean>(false);
+
   onSearchInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     this.searchSubject.next(input.value);
+    this.searchError.set('');
+  }
+
+  async onSearchSubmit(event: Event): Promise<void> {
+    event.preventDefault();
+    const term = this.searchTerm().trim();
+    if (!term) return;
+
+    if (!term.startsWith('angor1')) {
+      return;
+    }
+
+    await this.lookupProjectById(term);
+  }
+
+  private async lookupProjectById(term: string): Promise<void> {
+    if (this.isSearchingProject()) return;
+
+    this.searchError.set('');
+    this.isSearchingProject.set(true);
+
+    try {
+      // First check if we already have it loaded
+      const project = this.indexer.getProject(term);
+      if (project) {
+        this.router.navigate(['/project', term]);
+        return;
+      }
+
+      // Fetch from blockchain
+      const fetched = await this.indexer.fetchProject(term);
+      if (fetched) {
+        this.router.navigate(['/project', term]);
+      } else {
+        this.searchError.set('Project not found. Please check the project ID and try again.');
+      }
+    } catch (error) {
+      console.error('Error searching for project:', error);
+      this.searchError.set('Failed to look up project. Please try again.');
+    } finally {
+      this.isSearchingProject.set(false);
+    }
   }
 
   clearSearch(): void {
     this.searchTerm.set('');
     this.searchSubject.next('');
+    this.searchError.set('');
   }
 
   getRandomColor(seed: string): string {

--- a/src/app/pages/explore/explore.component.ts
+++ b/src/app/pages/explore/explore.component.ts
@@ -116,7 +116,14 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
     });
 
 
-    if (sort === 'funding') {
+    if (sort === 'default') {
+      // Chronological order: newest first by Nostr event creation time
+      filtered = [...filtered].sort((a, b) => {
+        const timeA = a.details_created_at || 0;
+        const timeB = b.details_created_at || 0;
+        return timeB - timeA;
+      });
+    } else if (sort === 'funding') {
       filtered = [...filtered].sort((a, b) => {
         const percentA = this.getFundingPercentage(a);
         const percentB = this.getFundingPercentage(b);
@@ -245,6 +252,9 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
       console.log(`[Angor Debug] ExploreComponent.ngOnInit: hasState=${this.exploreState.hasState}, projects.length=${this.indexer.projects().length} → restoring cached state, offset=${this.exploreState.offset}`);
       this.indexer.restoreOffset(this.exploreState.offset);
       this.observeProjectCards();
+
+      // Still fetch latest data so newly created projects appear
+      this.indexer.fetchLatestProjects();
     } else {
       console.log(`[Angor Debug] ExploreComponent.ngOnInit: hasState=${this.exploreState.hasState}, projects.length=${this.indexer.projects().length} → fresh fetch`);
       this.exploreState.clearState();
@@ -255,8 +265,8 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
         this.observeProjectCards();
       }
 
-      // Always fetch fresh data (will deduplicate against cached projects)
-      await this.indexer.fetchProjects();
+      // Always fetch fresh data from newest (will deduplicate against cached projects)
+      await this.indexer.fetchLatestProjects();
       this.observeProjectCards();
     }
   }

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -494,9 +494,10 @@ export class ProjectComponent implements OnInit, OnDestroy {
         this.loadOnChainStats();
 
         if (!projectData.details) {
-
-          this.relay.fetchData([projectData.nostrEventId]);
-
+          // Guard: only fetch from Nostr if we have a valid event ID
+          if (projectData.nostrEventId) {
+            this.relay.fetchData([projectData.nostrEventId]);
+          }
         } else {
           this.user = new NDKUser({
             pubkey: projectData.details.nostrPubKey,
@@ -526,14 +527,22 @@ export class ProjectComponent implements OnInit, OnDestroy {
             }
 
             this.projectEvent = event;
-            projectData!.details = details;
 
+            // Update through signal to avoid closure divergence
+            const current = this.project()!;
+            current.details = details;
+            current.details_created_at = event.created_at;
 
             this.user = new NDKUser({
-              pubkey: projectData!.details.nostrPubKey,
+              pubkey: details.nostrPubKey,
               relayUrls: this.relay.relayUrls(),
             });
 
+            // Trigger signal reactivity so the template updates
+            this.project.set({ ...current });
+
+            // Re-trigger stats now that details are available
+            this.loadOnChainStats();
 
             this.relay.fetchProfile([details.nostrPubKey]);
           }
@@ -547,7 +556,8 @@ export class ProjectComponent implements OnInit, OnDestroy {
 
           const update: NDKUserProfile = JSON.parse(event.content);
 
-          if (event.pubkey == projectData!.details?.nostrPubKey) {
+          const current = this.project();
+          if (event.pubkey == current?.details?.nostrPubKey) {
             if (this.profileEvent) {
               if (this.profileEvent.created_at! > event.created_at!) {
                 {
@@ -557,13 +567,16 @@ export class ProjectComponent implements OnInit, OnDestroy {
             }
 
             this.profileEvent = event;
-            projectData!.metadata = update;
+            current.metadata = update;
 
             this.title.setTitle(update.name);
 
-            projectData!.externalIdentities =
+            current.externalIdentities =
               this.utils.getExternalIdentities(event);
-            projectData!.externalIdentities_created_at = event.created_at;
+            current.externalIdentities_created_at = event.created_at;
+
+            // Trigger signal reactivity so the template updates
+            this.project.set({ ...current });
           }
         });
 
@@ -607,6 +620,9 @@ export class ProjectComponent implements OnInit, OnDestroy {
           } else {
             console.warn('Unknown tag:', tag);
           }
+
+          // Trigger signal reactivity so the template updates
+          this.project.set({ ...project });
         });
 
         this.subscriptions.push(projectSub, profileSub, contentSub);

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -741,6 +741,18 @@ export class IndexerService {
     }
   }
 
+  /**
+   * Fetches the newest projects from Nostr, starting from the top.
+   * Unlike fetchProjects / loadMore, this always resets the pagination
+   * cursor so newly created projects are discovered even when cached
+   * projects are already loaded.
+   */
+  async fetchLatestProjects(): Promise<void> {
+    this.oldestEventTimestamp = undefined;
+    this.totalProjectsFetched = false;
+    await this.fetchProjects();
+  }
+
   private async _doFetchProjects(): Promise<void> {
     // Maximum number of consecutive empty batches before giving up.
     // Prevents infinite loops when relays return only non-project events.


### PR DESCRIPTION
## Summary
- Added a new `/app` download page with OS detection, platform-specific download links (GitHub Releases), and an Android section with links to GitHub Releases and Zapstore
- Changed the App nav item in both desktop and mobile header from an external link (`angor.io/app`) to an internal `routerLink=/app`