### PR TITLE
fix: fallback to cached on-chain data when funding tx missing from indexer

### DIFF
--- a/src/app/pages/explore/explore.component.ts
+++ b/src/app/pages/explore/explore.component.ts
@@ -387,7 +387,10 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private async loadProjectStats(project: any) {
     try {
-      project.stats = await this.indexer.fetchProjectStats(project.projectIdentifier);
+      project.stats = await this.indexer.fetchProjectStats(
+        project.projectIdentifier,
+        project.trxId
+      );
     } catch (error) {
       console.error('Error loading project stats:', error);
     }

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -166,9 +166,12 @@ export class ProjectComponent implements OnInit, OnDestroy {
     this.onChainStatsError.set(null);
 
     try {
+      const project = this.project();
       const stats = await this.investorService.getProjectOnChainStats(
         this.projectId,
-        this.project()?.details
+        project?.details,
+        project?.trxId,
+        project?.founderKey
       );
 
       if (stats) {

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -184,7 +184,8 @@ export class IndexerService {
       { url: 'https://electrs.angor.online/', isPrimary: false }
     ],
     testnet: [
-      { url: 'https://signet.angor.online/', isPrimary: true }
+      { url: 'https://signet.angor.online/', isPrimary: true },
+      { url: 'https://test.indexer.angor.io/', isPrimary: false }
     ]
   });
 
@@ -284,7 +285,10 @@ export class IndexerService {
         { url: 'https://fulcrum.angor.online/', isPrimary: true },
         { url: 'https://electrs.angor.online/', isPrimary: false }
       ],
-      testnet: [{ url: 'https://signet.angor.online/', isPrimary: true }]
+      testnet: [
+        { url: 'https://signet.angor.online/', isPrimary: true },
+        { url: 'https://test.indexer.angor.io/', isPrimary: false }
+      ]
     };
   }
 
@@ -1128,7 +1132,7 @@ export class IndexerService {
    *
    * Mirrors MempoolIndexerAngorApi.GetProjectStatsAsync (ReadFromAngorApi=false).
    */
-  async fetchProjectStats(id: string): Promise<ProjectStats | null> {
+  async fetchProjectStats(id: string, knownTrxId?: string): Promise<ProjectStats | null> {
     try {
       this.loading.set(true);
       const address = this.convertAngorKeyToBitcoinAddress(id);
@@ -1151,6 +1155,11 @@ export class IndexerService {
           fundingTxId = tx.txid;
           break;
         }
+      }
+
+      // Fallback: use cached trxId when funding tx is missing from address list
+      if (!fundingTxId && knownTrxId) {
+        fundingTxId = knownTrxId;
       }
       if (!fundingTxId) return null;
 
@@ -1203,7 +1212,8 @@ export class IndexerService {
   async fetchProjectInvestments(
     projectId: string,
     offset = 0,
-    limit = 10
+    limit = 10,
+    knownTrxId?: string
   ): Promise<ProjectInvestment[]> {
     try {
       const address = this.convertAngorKeyToBitcoinAddress(projectId);
@@ -1226,6 +1236,11 @@ export class IndexerService {
           fundingTxId = tx.txid;
           break;
         }
+      }
+
+      // Fallback: use cached trxId when funding tx is missing from address list
+      if (!fundingTxId && knownTrxId) {
+        fundingTxId = knownTrxId;
       }
       if (!fundingTxId) return [];
 

--- a/src/app/services/investor.service.ts
+++ b/src/app/services/investor.service.ts
@@ -440,7 +440,12 @@ export class InvestorService {
    * This mirrors the logic in the Angor C# MempoolIndexerMappers when
    * ReadFromAngorApi is false.
    */
-  async getProjectOnChainStats(projectId: string, details?: ProjectUpdate): Promise<OnChainProjectStats | null> {
+  async getProjectOnChainStats(
+    projectId: string,
+    details?: ProjectUpdate,
+    knownTrxId?: string,
+    knownFounderKey?: string
+  ): Promise<OnChainProjectStats | null> {
     try {
       const address = this.convertAngorKeyToBitcoinAddress(projectId);
       console.log(`[InvestorService] Project ${projectId} -> address ${address}`);
@@ -475,6 +480,16 @@ export class InvestorService {
           console.log(`[InvestorService] Found funding tx: ${tx.txid}, founder: ${founderKey}`);
           break;
         }
+      }
+
+      // Fallback: use cached on-chain data when the funding tx is missing from
+      // the address transaction list (e.g. indexer only returns recent txs).
+      if (!fundingTx && knownTrxId) {
+        console.log(`[InvestorService] Funding tx not in address list, using cached trxId: ${knownTrxId}`);
+        fundingTx = { txid: knownTrxId } as MempoolTransaction;
+      }
+      if (!founderKey && knownFounderKey) {
+        founderKey = knownFounderKey;
       }
 
       if (!fundingTx || !founderKey) {


### PR DESCRIPTION
## Problem

The signet.angor.online indexer's \/address/{address}/txs\ endpoint omits older transactions (including the funding transaction), returning only ~10 recent transactions. This causes:

- \InvestorService.getProjectOnChainStats()\ returns null → 0 investors shown on project detail page
- \IndexerService.fetchProjectStats()\ returns null → no stats on explore page cards
- \IndexerService.validateAndAddProjects()\ fails for all new candidates

The funding transaction *can* be fetched directly by txid via \/tx/{txid}\, confirming it exists in the indexer.

## Fix

1. **investor.service.ts** — \getProjectOnChainStats()\ now accepts optional \knownTrxId\ and \knownFounderKey\ parameters, falling back to cached values when the funding tx is missing from the address transaction list.

2. **indexer.service.ts** — Same fallback pattern added to \etchProjectStats()\ and \etchProjectInvestments()\ with optional \knownTrxId\ parameter.

3. **project.component.ts** — \loadOnChainStats()\ now passes \project.trxId\ and \project.founderKey\ from cached project data.

4. **explore.component.ts** — \loadProjectStats()\ now passes \project.trxId\.

5. Added \https://test.indexer.angor.io/\ as a secondary testnet indexer (non-primary).