### PR TITLE
fix: remove premature pagination break on mempool address txs

### DIFF
--- a/src/app/pages/explore/explore.component.ts
+++ b/src/app/pages/explore/explore.component.ts
@@ -387,10 +387,7 @@ export class ExploreComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private async loadProjectStats(project: any) {
     try {
-      project.stats = await this.indexer.fetchProjectStats(
-        project.projectIdentifier,
-        project.trxId
-      );
+      project.stats = await this.indexer.fetchProjectStats(project.projectIdentifier);
     } catch (error) {
       console.error('Error loading project stats:', error);
     }

--- a/src/app/pages/project/project.component.ts
+++ b/src/app/pages/project/project.component.ts
@@ -166,12 +166,9 @@ export class ProjectComponent implements OnInit, OnDestroy {
     this.onChainStatsError.set(null);
 
     try {
-      const project = this.project();
       const stats = await this.investorService.getProjectOnChainStats(
         this.projectId,
-        project?.details,
-        project?.trxId,
-        project?.founderKey
+        this.project()?.details
       );
 
       if (stats) {

--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -137,9 +137,8 @@ export class IndexerService {
   private readonly LIMIT = 8;
   private indexerUrl = 'https://signet.angor.online/';
 
-  // Mempool.space pagination — the API returns at most 25 transactions per page.
-  private readonly MEMPOOL_PAGE_SIZE = 25;
-  // Safety cap on address transaction pagination (25 × 20 = 500 txs max).
+  // Mempool.space pagination — the blockcore indexer returns at most 10 tx per page.
+  // We paginate with ?after_txid= until the response is empty or we hit the safety cap.
   private readonly MEMPOOL_MAX_PAGES = 20;
 
   // Nostr-first cursor-based pagination (using `until` timestamp)
@@ -570,7 +569,6 @@ export class IndexerService {
         const txs: MempoolTx[] = await response.json();
         if (!txs || txs.length === 0) break;
         all.push(...txs);
-        if (txs.length < this.MEMPOOL_PAGE_SIZE) break;
         lastTxId = txs[txs.length - 1].txid;
       } catch (err) {
         console.warn('[Angor Debug] fetchMempoolAddressTxs error:', err);
@@ -1132,7 +1130,7 @@ export class IndexerService {
    *
    * Mirrors MempoolIndexerAngorApi.GetProjectStatsAsync (ReadFromAngorApi=false).
    */
-  async fetchProjectStats(id: string, knownTrxId?: string): Promise<ProjectStats | null> {
+  async fetchProjectStats(id: string): Promise<ProjectStats | null> {
     try {
       this.loading.set(true);
       const address = this.convertAngorKeyToBitcoinAddress(id);
@@ -1155,11 +1153,6 @@ export class IndexerService {
           fundingTxId = tx.txid;
           break;
         }
-      }
-
-      // Fallback: use cached trxId when funding tx is missing from address list
-      if (!fundingTxId && knownTrxId) {
-        fundingTxId = knownTrxId;
       }
       if (!fundingTxId) return null;
 
@@ -1212,8 +1205,7 @@ export class IndexerService {
   async fetchProjectInvestments(
     projectId: string,
     offset = 0,
-    limit = 10,
-    knownTrxId?: string
+    limit = 10
   ): Promise<ProjectInvestment[]> {
     try {
       const address = this.convertAngorKeyToBitcoinAddress(projectId);
@@ -1236,11 +1228,6 @@ export class IndexerService {
           fundingTxId = tx.txid;
           break;
         }
-      }
-
-      // Fallback: use cached trxId when funding tx is missing from address list
-      if (!fundingTxId && knownTrxId) {
-        fundingTxId = knownTrxId;
       }
       if (!fundingTxId) return [];
 

--- a/src/app/services/investor.service.ts
+++ b/src/app/services/investor.service.ts
@@ -166,11 +166,6 @@ export class InvestorService {
 
       allTxs.push(...txs);
 
-      // Mempool.space returns 25 txs per page
-      if (txs.length < 25) {
-        break;
-      }
-
       lastTxId = txs[txs.length - 1].txid;
     }
 
@@ -440,12 +435,7 @@ export class InvestorService {
    * This mirrors the logic in the Angor C# MempoolIndexerMappers when
    * ReadFromAngorApi is false.
    */
-  async getProjectOnChainStats(
-    projectId: string,
-    details?: ProjectUpdate,
-    knownTrxId?: string,
-    knownFounderKey?: string
-  ): Promise<OnChainProjectStats | null> {
+  async getProjectOnChainStats(projectId: string, details?: ProjectUpdate): Promise<OnChainProjectStats | null> {
     try {
       const address = this.convertAngorKeyToBitcoinAddress(projectId);
       console.log(`[InvestorService] Project ${projectId} -> address ${address}`);
@@ -480,16 +470,6 @@ export class InvestorService {
           console.log(`[InvestorService] Found funding tx: ${tx.txid}, founder: ${founderKey}`);
           break;
         }
-      }
-
-      // Fallback: use cached on-chain data when the funding tx is missing from
-      // the address transaction list (e.g. indexer only returns recent txs).
-      if (!fundingTx && knownTrxId) {
-        console.log(`[InvestorService] Funding tx not in address list, using cached trxId: ${knownTrxId}`);
-        fundingTx = { txid: knownTrxId } as MempoolTransaction;
-      }
-      if (!founderKey && knownFounderKey) {
-        founderKey = knownFounderKey;
       }
 
       if (!fundingTx || !founderKey) {


### PR DESCRIPTION
## Problem

The blockcore indexer returns 10 transactions per page by default, but the code assumed 25. This caused pagination to stop after the first page (10 < 25 triggered the break), missing older transactions including the funding transaction. Projects with more than 10 txs at their address would show incorrect investor counts (e.g. 3 instead of 14).

## Root Cause

Both \InvestorService.fetchAddressTransactions()\ and \IndexerService.fetchMempoolAddressTxs()\ had a premature break: \if (txs.length < 25) break;\. The blockcore indexer's actual default page size is 10, so the first page of 10 results always triggered this break, never fetching page 2.

## Fix

Removed the premature page-size check. Pagination now continues until the API returns an empty response, correctly recovering all transactions for an address. A safety cap (\MEMPOOL_MAX_PAGES = 20\) remains in place in the indexer service.

Verified against the signet project \ngor1qxuxx7gd6xxhkxz7evjmthgtqtsualqpu0vxxdd\:  
- Before fix: 10 txs (page 1 only), no funding tx found → 0 investors  
- After fix: 16 txs (both pages), funding tx found → 15 investors