### PR TITLE
fix: prevent infinite loop in paginated transaction fetching

### DIFF
--- a/src/app/services/indexer.service.ts
+++ b/src/app/services/indexer.service.ts
@@ -556,6 +556,7 @@ export class IndexerService {
 
     const all: MempoolTx[] = [];
     let lastTxId: string | undefined;
+    let prevLastTxId: string | undefined;
 
     for (let page = 0; page < this.MEMPOOL_MAX_PAGES; page++) {
       let url = `${this.indexerUrl}api/v1/address/${address}/txs`;
@@ -569,7 +570,11 @@ export class IndexerService {
         const txs: MempoolTx[] = await response.json();
         if (!txs || txs.length === 0) break;
         all.push(...txs);
+        prevLastTxId = lastTxId;
         lastTxId = txs[txs.length - 1].txid;
+        // Stop if the cursor didn't advance (same page returned again)
+        // or we got fewer than 10 results (last page).
+        if (lastTxId === prevLastTxId || txs.length < 10) break;
       } catch (err) {
         console.warn('[Angor Debug] fetchMempoolAddressTxs error:', err);
         break;

--- a/src/app/services/investor.service.ts
+++ b/src/app/services/investor.service.ts
@@ -138,14 +138,16 @@ export class InvestorService {
 
   /**
    * Fetches all transactions for a given address from the mempool.space-compatible API.
-   * Handles pagination (mempool.space returns max 25 txs per request).
+   * Handles pagination with ?after_txid= cursor.
    */
   async fetchAddressTransactions(address: string): Promise<MempoolTransaction[]> {
     const baseUrl = this.getApiBaseUrl();
     const allTxs: MempoolTransaction[] = [];
     let lastTxId: string | undefined;
+    let prevLastTxId: string | undefined;
+    const MAX_PAGES = 20;
 
-    while (true) {
+    for (let page = 0; page < MAX_PAGES; page++) {
       let url = `${baseUrl}/address/${address}/txs`;
       if (lastTxId) {
         url += `?after_txid=${lastTxId}`;
@@ -166,7 +168,14 @@ export class InvestorService {
 
       allTxs.push(...txs);
 
+      prevLastTxId = lastTxId;
       lastTxId = txs[txs.length - 1].txid;
+
+      // Stop if the cursor didn't advance (same page returned again)
+      // or we got fewer than 10 results (last page).
+      if (lastTxId === prevLastTxId || txs.length < 10) {
+        break;
+      }
     }
 
     return allTxs;


### PR DESCRIPTION
## Problem

After removing the premature pagination break (cd29d4a), both \etchMempoolAddressTxs\ and \etchAddressTransactions\ had no stop condition for the last page. The cursor (\lastTxId\) stays the same when the API returns the final page, causing an infinite loop of identical requests (visible as repeated 304 Not Modified responses).

## Fix

**indexer.service.ts** (\etchMempoolAddressTxs\) and **investor.service.ts** (\etchAddressTransactions\):

- Track \prevLastTxId\ to detect when the cursor doesn't advance (same page returned again)
- Break when fewer than 10 results are returned (last page)
- Replace unbounded \while(true)\ with bounded \or\ loop (max 20 pages) in investor.service.ts